### PR TITLE
Rename config and well-known URL paths from `warg` to `wasm-pkg`

### DIFF
--- a/crates/wasm-pkg-loader/src/config/toml.rs
+++ b/crates/wasm-pkg-loader/src/config/toml.rs
@@ -35,7 +35,7 @@ impl super::ClientConfig {
         let Some(config_dir) = dirs::config_dir() else {
             return Ok(None);
         };
-        let path = config_dir.join("warg").join("config.toml");
+        let path = config_dir.join("wasm-pkg").join("config.toml");
         if !path.exists() {
             return Ok(None);
         }

--- a/crates/wasm-pkg-loader/src/meta.rs
+++ b/crates/wasm-pkg-loader/src/meta.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 use crate::Error;
 
-const WELL_KNOWN_PATH: &str = ".well-known/warg/registry.json";
+const WELL_KNOWN_PATH: &str = ".well-known/wasm-pkg/registry.json";
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Fixes #8 
Fixes #9 