### PR TITLE
oci: Make all docker credential errors non-fatal

### DIFF
--- a/crates/wasm-pkg-loader/src/source/oci.rs
+++ b/crates/wasm-pkg-loader/src/source/oci.rs
@@ -128,14 +128,18 @@ impl OciSource {
                     "identity tokens not supported"
                 )));
             }
-            Err(err @ CredentialRetrievalError::HelperFailure { .. }) => {
-                tracing::info!("Docker credential helper failed: {err:?}");
+            Err(err) => {
+                if matches!(
+                    err,
+                    CredentialRetrievalError::ConfigNotFound
+                        | CredentialRetrievalError::ConfigReadError
+                        | CredentialRetrievalError::NoCredentialConfigured
+                ) {
+                    tracing::debug!("Failed to look up OCI credentials: {err}");
+                } else {
+                    tracing::warn!("Failed to look up OCI credentials: {err}");
+                };
             }
-            Err(
-                CredentialRetrievalError::ConfigNotFound
-                | CredentialRetrievalError::NoCredentialConfigured,
-            ) => (),
-            Err(err) => return Err(Error::CredentialError(err.into())),
         }
 
         Ok(RegistryAuth::Anonymous)

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -7,6 +7,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use futures_util::TryStreamExt;
 use package_spec::PackageSpec;
 use tokio::io::AsyncWriteExt;
+use tracing::level_filters::LevelFilter;
 use wasm_pkg_loader::ClientConfig;
 use wit_component::DecodedWasm;
 
@@ -191,7 +192,11 @@ impl GetCommand {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::WARN.into())
+                .from_env_lossy(),
+        )
         .init();
 
     let cli = Cli::parse();


### PR DESCRIPTION
The docker_credential crate doesn't provide a ton of precision in its errors, so we'll downgrade all of its errors to a warning at worst to prevent unnecessary failures. This should remove an entire class of spurious failures at the expense of slightly harder debugging in certain cases.

Fixes #19 