### PR TITLE
add binary artifacts publishing for `cargo binstall`

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,0 +1,103 @@
+name: "Publish binaries"
+
+on:
+  push:
+    branches: ["main"]
+    tags:
+      - "v*"
+    
+jobs:
+  bump_dev_release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'bytecodealliance/wasm-pkg-tools'
+    name: Create dev release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Login GH CLI
+        run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
+      - name: Delete old dev release
+        run: gh release delete -R bytecodealliance/wasm-pkg-tools dev -y || true
+      - name: Create new latest release
+        run: gh release create -R bytecodealliance/wasm-pkg-tools dev --prerelease --notes "Published artifacts from the latest build"
+
+  publish_dev_release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'bytecodealliance/wasm-pkg-tools'
+    name: Publish to dev release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - rust-target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - rust-target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - rust-target: x86_64-apple-darwin
+            os: macos-latest
+          - rust-target: aarch64-apple-darwin
+            os: macos-latest
+          - rust-target: x86_64-pc-windows-gnu
+            os: windows-latest
+
+    needs:
+      - bump_dev_release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable --no-self-update && rustup default stable && rustup target add ${{ matrix.rust-target }}
+      - run: cargo build --release --target ${{ matrix.rust-target }}
+        if: ${{ ! matrix.cross }}
+      - run: cargo install cross
+        if: ${{ matrix.cross }}
+      - run: cross build --release --target ${{ matrix.rust-target }}
+        if: ${{ matrix.cross }}
+      - run: mv ./target/${{ matrix.rust-target }}/release/wkg.exe ./target/${{ matrix.rust-target }}/release/wkg-${{ matrix.rust-target }}
+        if: matrix.os == 'windows-latest'
+      - run: mv ./target/${{ matrix.rust-target }}/release/wkg ./target/${{ matrix.rust-target }}/release/wkg-${{ matrix.rust-target }}
+        if: matrix.os != 'windows-latest'
+      - name: Login GH CLI
+        shell: bash
+        run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
+      - run: gh release upload -R bytecodealliance/wasm-pkg-tools --clobber dev target/${{ matrix.rust-target }}/release/wkg-${{ matrix.rust-target }}
+
+  publish_tagged_release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'bytecodealliance/wasm-pkg-tools'
+    name: Publish to tagged release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - rust-target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - rust-target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - rust-target: x86_64-apple-darwin
+            os: macos-latest
+          - rust-target: aarch64-apple-darwin
+            os: macos-latest
+          - rust-target: x86_64-pc-windows-gnu
+            os: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable --no-self-update && rustup default stable && rustup target add ${{ matrix.rust-target }}
+      - run: cargo build --release --target ${{ matrix.rust-target }}
+        if: ${{ ! matrix.cross }}
+      - run: cargo install cross
+        if: ${{ matrix.cross }}
+      - run: cross build --release --target ${{ matrix.rust-target }}
+        if: ${{ matrix.cross }}
+      - run: mv ./target/${{ matrix.rust-target }}/release/wkg.exe ./target/${{ matrix.rust-target }}/release/wkg-${{ matrix.rust-target }}
+        if: matrix.os == 'windows-latest'
+      - run: mv ./target/${{ matrix.rust-target }}/release/wkg ./target/${{ matrix.rust-target }}/release/wkg-${{ matrix.rust-target }}
+        if: matrix.os != 'windows-latest'
+      - name: Login GH CLI
+        shell: bash
+        run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
+      - run: gh release upload -R bytecodealliance/wasm-pkg-tools --clobber ${{ github.ref_name }} target/${{ matrix.rust-target }}/release/wkg-${{ matrix.rust-target }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,11 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH",
+]
+env.passthrough = [
+    "OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu",
+    "OPENSSL_INCLUDE_DIR=/usr/include/aarch64-linux-gnu/openssl",
+    "OPENSSL_STATIC=yes"
+]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"


### PR DESCRIPTION
After the following release, you can do:

`cargo install cargo-binstall` (if you don't have `cargo-binstall`)

`cargo binstall wkg` (which installs from binary artifacts built by the CI instead of building from source)