### PR TITLE
Support `protocol = "http"` in OCI registry config

### DIFF
--- a/crates/wasm-pkg-loader/src/config.rs
+++ b/crates/wasm-pkg-loader/src/config.rs
@@ -73,13 +73,10 @@ impl ClientConfig {
     pub fn set_oci_registry_config(
         &mut self,
         registry: impl Into<String>,
-        client_config: Option<OciClientConfig>,
+        client_config: OciClientConfig,
         credentials: Option<BasicCredentials>,
     ) -> Result<&mut Self, Error> {
-        if client_config
-            .as_ref()
-            .is_some_and(|cfg| cfg.platform_resolver.is_some())
-        {
+        if client_config.platform_resolver.is_some() {
             Error::InvalidConfig(anyhow::anyhow!(
                 "oci_distribution::client::ClientConfig::platform_resolver not supported"
             ));

--- a/crates/wasm-pkg-loader/src/source/oci.rs
+++ b/crates/wasm-pkg-loader/src/source/oci.rs
@@ -22,18 +22,18 @@ const WASM_LAYER_MEDIA_TYPES: &[&str] = &[
 
 #[derive(Default)]
 pub struct OciConfig {
-    pub client_config: Option<ClientConfig>,
+    pub client_config: ClientConfig,
     pub credentials: Option<BasicCredentials>,
 }
 
 impl Clone for OciConfig {
     fn clone(&self) -> Self {
-        let client_config = self.client_config.as_ref().map(|cfg| ClientConfig {
-            protocol: cfg.protocol.clone(),
-            extra_root_certificates: cfg.extra_root_certificates.clone(),
+        let client_config = ClientConfig {
+            protocol: self.client_config.protocol.clone(),
+            extra_root_certificates: self.client_config.extra_root_certificates.clone(),
             platform_resolver: None,
-            ..*cfg
-        });
+            ..self.client_config
+        };
         Self {
             client_config,
             credentials: self.credentials.clone(),
@@ -44,7 +44,7 @@ impl Clone for OciConfig {
 impl std::fmt::Debug for OciConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OciConfig")
-            .field("client_config", &self.client_config.as_ref().map(|_| "..."))
+            .field("client_config", &"...")
             .field("credentials", &self.credentials)
             .finish()
     }
@@ -68,7 +68,7 @@ impl OciSource {
             client_config,
             credentials,
         } = config;
-        let client = oci_distribution::Client::new(client_config.unwrap_or_default());
+        let client = oci_distribution::Client::new(client_config);
 
         let oci_registry = registry_meta.oci_registry.unwrap_or(registry);
 

--- a/crates/wasm-pkg-loader/tests/e2e/src/main.rs
+++ b/crates/wasm-pkg-loader/tests/e2e/src/main.rs
@@ -41,10 +41,10 @@ async fn fetch_smoke_test() {
         .set_default_registry("localhost:5000")
         .set_oci_registry_config(
             "localhost:5000",
-            Some(oci_client::ClientConfig {
+            oci_client::ClientConfig {
                 protocol: oci_client::ClientProtocol::Http,
                 ..Default::default()
-            }),
+            },
             None,
         )
         .unwrap();


### PR DESCRIPTION
This is useful/required for local registries e.g.

```toml
default_registry = "localhost:5000"

[registry."localhost:5000"]
type = "oci"
protocol = "http"
```