### PR TITLE
ref(wasm-pkg-loader): turn default features off for tracing-subscriber crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,16 +1781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,12 +2003,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -3329,18 +3313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -3350,15 +3322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -3448,12 +3417,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ license = "Apache-2.0 WITH LLVM-exception"
 [workspace.dependencies]
 tokio = "1.35.1"
 tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter"] }
 wasm-pkg-loader = { version = "0.3.0", path = "crates/wasm-pkg-loader" }

--- a/crates/wasm-pkg-loader/Cargo.toml
+++ b/crates/wasm-pkg-loader/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1.35.1", features = ["rt", "macros"] }
 tokio-util = { version = "0.7.10", features = ["io"] }
 toml = "0.8.8"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { workspace = true }
 url = "2.5.0"
 warg-client = "0.7.0"
 warg-protocol = "0.7.0"

--- a/crates/wkg/Cargo.toml
+++ b/crates/wkg/Cargo.toml
@@ -13,6 +13,6 @@ futures-util = { version = "0.3.29", features = ["io"] }
 tempfile = "3.10.1"
 tokio = { workspace = true, features = ["macros", "rt"] }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { workspace = true }
 wasm-pkg-loader = { workspace = true }
 wit-component = "0.207"


### PR DESCRIPTION
This PR disables the default features for the tracing-subscriber crate, primarily to avoid bringing in the [tracing-log](https://crates.io/crates/tracing-log) crate, which can introduce issues in downstream consumers because it attempts to init a global logger which may already be initialized (ref https://github.com/spinkube/containerd-shim-spin/issues/61).

If this project does have a need to utilize the tracing-log crate, we could also go an opt-out approach.