### PR TITLE
ref(*): Switches all tracing macros to use fields

### DIFF
--- a/crates/wasm-pkg-loader/src/config.rs
+++ b/crates/wasm-pkg-loader/src/config.rs
@@ -105,14 +105,14 @@ impl ClientConfig {
 
     pub(crate) fn resolve_package_registry(&self, package: &PackageRef) -> Result<&str, Error> {
         let namespace = package.namespace();
-        tracing::debug!("Resolving registry for {namespace:?}");
+        tracing::debug!(?namespace, "Resolving registry");
 
         if let Some(registry) = self.namespace_registries.get(namespace.as_ref()) {
-            tracing::debug!("Found namespace-specific registry {registry:?}");
+            tracing::debug!(?registry, "Found namespace-specific registry");
             return Ok(registry);
         }
         if let Some(registry) = &self.default_registry {
-            tracing::debug!("No namespace-specific registry; using default {registry:?}");
+            tracing::debug!(?registry, "No namespace-specific registry; using default");
             return Ok(registry);
         }
         Err(Error::NoRegistryForNamespace(namespace.to_owned()))

--- a/crates/wasm-pkg-loader/src/lib.rs
+++ b/crates/wasm-pkg-loader/src/lib.rs
@@ -91,7 +91,7 @@ impl Client {
         if !self.sources.contains_key(&registry) {
             let registry_config = self.config.registry_configs.get(&registry).cloned();
 
-            tracing::debug!("Resolved registry config: {registry_config:?}");
+            tracing::debug!(?registry_config, "Resolved registry config");
 
             let registry_meta = RegistryMeta::fetch_or_default(&registry).await;
 
@@ -108,9 +108,10 @@ impl Client {
                 config::RegistryConfig::Oci(config) => {
                     Box::new(self.build_oci_client(&registry, registry_meta, config)?)
                 }
-                config::RegistryConfig::Warg(config) => {
-                    Box::new(self.build_warg_client(&registry, registry_meta, config).await?)
-                }
+                config::RegistryConfig::Warg(config) => Box::new(
+                    self.build_warg_client(&registry, registry_meta, config)
+                        .await?,
+                ),
             };
             self.sources.insert(registry.clone(), source);
         }
@@ -123,7 +124,7 @@ impl Client {
         registry_meta: RegistryMeta,
         config: OciConfig,
     ) -> Result<OciSource, Error> {
-        tracing::debug!("Building new OCI client for {registry:?}");
+        tracing::debug!(?registry, "Building new OCI client");
         OciSource::new(registry.to_string(), config, registry_meta)
     }
 
@@ -133,7 +134,7 @@ impl Client {
         registry_meta: RegistryMeta,
         config: WargConfig,
     ) -> Result<WargSource, Error> {
-        tracing::debug!("Building new Warg client for {registry:?}");
+        tracing::debug!(?registry, "Building new Warg client");
         WargSource::new(registry.to_string(), config, registry_meta).await
     }
 }

--- a/crates/wasm-pkg-loader/src/meta.rs
+++ b/crates/wasm-pkg-loader/src/meta.rs
@@ -18,7 +18,7 @@ impl RegistryMeta {
     pub async fn fetch_or_default(domain: &str) -> Self {
         match Self::fetch(domain).await {
             Ok(Some(meta)) => {
-                tracing::debug!("Got registry metadata {meta:?}");
+                tracing::debug!(?meta, "Got registry metadata");
                 meta
             }
             Ok(None) => {
@@ -26,7 +26,7 @@ impl RegistryMeta {
                 Default::default()
             }
             Err(err) => {
-                tracing::warn!("Error fetching registry metadata: {err}");
+                tracing::warn!(error = ?err, "Error fetching registry metadata");
                 Default::default()
             }
         }
@@ -46,7 +46,8 @@ impl RegistryMeta {
     }
 
     async fn fetch_url(url: &str) -> anyhow::Result<Option<Self>> {
-        tracing::debug!("Fetching registry metadata from {url:?}");
+        tracing::debug!(?url, "Fetching registry metadata");
+
         let resp = reqwest::get(url).await?;
         if resp.status() == StatusCode::NOT_FOUND {
             return Ok(None);

--- a/crates/wasm-pkg-loader/src/source/local.rs
+++ b/crates/wasm-pkg-loader/src/source/local.rs
@@ -44,7 +44,7 @@ impl PackageSource for LocalSource {
     async fn list_all_versions(&mut self, package: &PackageRef) -> Result<Vec<VersionInfo>, Error> {
         let mut versions = vec![];
         let package_dir = self.package_dir(package);
-        tracing::debug!("Reading versions from {package_dir:?}");
+        tracing::debug!(?package_dir, "Reading versions from path");
         let mut entries = tokio::fs::read_dir(package_dir).await?;
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
@@ -74,7 +74,7 @@ impl PackageSource for LocalSource {
         version: &Version,
     ) -> Result<Release, Error> {
         let path = self.version_path(package, version);
-        tracing::debug!("Reading content from {path:?}");
+        tracing::debug!(path = %path.display(), "Reading content from path");
         let content_digest = ContentDigest::sha256_from_file(path).await?;
         Ok(Release {
             version: version.clone(),

--- a/crates/wasm-pkg-loader/src/source/oci.rs
+++ b/crates/wasm-pkg-loader/src/source/oci.rs
@@ -164,10 +164,10 @@ impl PackageSource for OciSource {
     async fn list_all_versions(&mut self, package: &PackageRef) -> Result<Vec<VersionInfo>, Error> {
         let reference = self.make_reference(package, None);
 
-        tracing::debug!("Listing tags for OCI reference {reference:?}");
+        tracing::debug!(?reference, "Listing tags for OCI reference");
         let auth = self.auth(&reference).await?;
         let resp = self.client.list_tags(&reference, &auth, None, None).await?;
-        tracing::trace!("List tags response: {resp:?}");
+        tracing::trace!(response = ?resp, "List tags response");
 
         // Return only tags that parse as valid semver versions.
         let versions = resp
@@ -179,7 +179,7 @@ impl PackageSource for OciSource {
                     yanked: false,
                 }),
                 Err(err) => {
-                    tracing::warn!("Ignoring invalid version tag {tag:?}: {err:?}");
+                    tracing::warn!(?tag, error = ?err, "Ignoring invalid version tag");
                     None
                 }
             })

--- a/crates/wasm-pkg-loader/tests/e2e/Cargo.lock
+++ b/crates/wasm-pkg-loader/tests/e2e/Cargo.lock
@@ -1801,16 +1801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,12 +2023,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -3372,18 +3356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -3393,15 +3365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -3487,12 +3456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,8 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a22d3c9026f2f6a628cf386963844cdb7baea3b3419ba090c9096da114f977d"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -3545,8 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b8b5a2b17e737e1847dbf4642e4ebe49f5df32a574520251ff080ef0a120423"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3590,8 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "warg-crypto"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834bf58863aa4bc3821732afb0c77e08a5cbf05f63ee93116acae694eab04460"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3610,8 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8a2dee6b14f5b0b0c461711a81cdef45d45ea94f8460cb6205cada7fec732a"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -3628,8 +3595,9 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4053a3276d3fee83645411b1b5f462f72402e70fbf645164274a3a0a2fd72538"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3650,8 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513ef81a5bb1ac5d7bd04f90d3c192dad8f590f4c02b3ef68d3ae4fbbb53c1d7"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3775,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-loader"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
This is a small update to make sure we're following best practice and logging the values as fields