### PR TITLE
Release 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-common"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-loader"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "wkg"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 
@@ -16,5 +16,5 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
     "fmt",
     "env-filter",
 ] }
-wasm-pkg-common = { version = "0.4.0", path = "crates/wasm-pkg-common" }
-wasm-pkg-loader = { version = "0.4.0", path = "crates/wasm-pkg-loader" }
+wasm-pkg-common = { version = "0.4.1", path = "crates/wasm-pkg-common" }
+wasm-pkg-loader = { version = "0.4.1", path = "crates/wasm-pkg-loader" }


### PR DESCRIPTION
I realized that wasm-pkg-loader was missing a bunch of useful re-exports.

This is basically a "usability bug fix", so just doing a patch release.