### PR TITLE
feat(*)!: Makes client methods no longer require mut

### DIFF
--- a/crates/wasm-pkg-client/src/caching/file.rs
+++ b/crates/wasm-pkg-client/src/caching/file.rs
@@ -3,10 +3,11 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use bytes::Bytes;
-use futures_util::{stream::BoxStream, StreamExt, TryStreamExt};
+use futures_util::{StreamExt, TryStreamExt};
 use tokio_util::io::{ReaderStream, StreamReader};
 use wasm_pkg_common::{digest::ContentDigest, Error};
+
+use crate::loader::ContentStream;
 
 use super::Cache;
 
@@ -26,11 +27,7 @@ impl FileCache {
 }
 
 impl Cache for FileCache {
-    async fn put_data(
-        &self,
-        digest: ContentDigest,
-        data: BoxStream<'_, Result<Bytes, Error>>,
-    ) -> Result<(), Error> {
+    async fn put_data(&self, digest: ContentDigest, data: ContentStream) -> Result<(), Error> {
         let path = self.root.join(digest.to_string());
         let mut file = tokio::fs::File::create(&path).await.map_err(|e| {
             Error::CacheError(anyhow::anyhow!("Unable to create file for cache {e}"))
@@ -43,10 +40,7 @@ impl Cache for FileCache {
             .map(|_| ())
     }
 
-    async fn get_data(
-        &self,
-        digest: &ContentDigest,
-    ) -> Result<Option<BoxStream<Result<Bytes, Error>>>, Error> {
+    async fn get_data(&self, digest: &ContentDigest) -> Result<Option<ContentStream>, Error> {
         let path = self.root.join(digest.to_string());
         let exists = tokio::fs::try_exists(&path)
             .await

--- a/crates/wasm-pkg-client/src/loader.rs
+++ b/crates/wasm-pkg-client/src/loader.rs
@@ -1,6 +1,8 @@
+use std::pin::Pin;
+
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures_util::{stream::BoxStream, StreamExt};
+use futures_util::{Stream, StreamExt};
 use wasm_pkg_common::{
     package::{PackageRef, Version},
     Error,
@@ -8,27 +10,26 @@ use wasm_pkg_common::{
 
 use crate::release::{Release, VersionInfo};
 
+/// An alias for a stream of content bytes
+pub type ContentStream = Pin<Box<dyn Stream<Item = Result<Bytes, Error>> + Send + 'static>>;
+
 #[async_trait]
 pub trait PackageLoader: Send {
-    async fn list_all_versions(&mut self, package: &PackageRef) -> Result<Vec<VersionInfo>, Error>;
+    async fn list_all_versions(&self, package: &PackageRef) -> Result<Vec<VersionInfo>, Error>;
 
-    async fn get_release(
-        &mut self,
-        package: &PackageRef,
-        version: &Version,
-    ) -> Result<Release, Error>;
+    async fn get_release(&self, package: &PackageRef, version: &Version) -> Result<Release, Error>;
 
     async fn stream_content_unvalidated(
-        &mut self,
+        &self,
         package: &PackageRef,
         release: &Release,
-    ) -> Result<BoxStream<Result<Bytes, Error>>, Error>;
+    ) -> Result<ContentStream, Error>;
 
     async fn stream_content(
-        &mut self,
+        &self,
         package: &PackageRef,
         release: &Release,
-    ) -> Result<BoxStream<Result<Bytes, Error>>, Error> {
+    ) -> Result<ContentStream, Error> {
         let stream = self.stream_content_unvalidated(package, release).await?;
         Ok(release.content_digest.validating_stream(stream).boxed())
     }

--- a/crates/wasm-pkg-client/src/warg/mod.rs
+++ b/crates/wasm-pkg-client/src/warg/mod.rs
@@ -56,7 +56,7 @@ impl WargBackend {
     }
 
     pub(crate) async fn fetch_package_info(
-        &mut self,
+        &self,
         package: &PackageRef,
     ) -> Result<PackageInfo, Error> {
         let package_name = package_ref_to_name(package)?;

--- a/crates/wasm-pkg-client/tests/e2e/src/main.rs
+++ b/crates/wasm-pkg-client/tests/e2e/src/main.rs
@@ -43,7 +43,7 @@ async fn fetch_smoke_test() {
     "#,
     )
     .unwrap();
-    let mut client = Client::new(config);
+    let client = Client::new(config);
 
     let package = FIXTURE_PACKAGE.parse().unwrap();
     let versions = client.list_all_versions(&package).await.unwrap();

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -73,7 +73,7 @@ impl GetArgs {
     pub async fn run(self) -> anyhow::Result<()> {
         let PackageSpec { package, version } = self.package_spec;
 
-        let mut client = {
+        let client = {
             let mut config = Config::global_defaults()?;
             if let Some(registry) = self.registry_args.registry.clone() {
                 tracing::debug!(%package, %registry, "overriding package registry");


### PR DESCRIPTION
We now lock access to the sources through a RwLock instead