### PR TITLE
fix: Resolve docker hub credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 target/
 .vscode
-
 *.swp
+.direnv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "itoa",
  "ryu",
@@ -4190,11 +4190,13 @@ name = "wkg"
 version = "0.4.1"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "clap",
  "docker_credential",
  "futures-util",
  "oci-distribution",
  "oci-wasm",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",

--- a/crates/wkg/Cargo.toml
+++ b/crates/wkg/Cargo.toml
@@ -20,3 +20,8 @@ tracing-subscriber = { workspace = true }
 wasm-pkg-common = { workspace = true }
 wasm-pkg-client = { workspace = true }
 wit-component = "0.207"
+
+[dev-dependencies]
+base64 = "0.22.1"
+serde_json = "1.0.118"
+


### PR DESCRIPTION
Fix resolving credentials from docker `config.json`. Add a new `server` parameter variant for
`docker_credential::get_credential`.

When using the default registry, it must be set to `https://index.docker.io/v1/`.
Retain the generic lookup for other registries.

Fixes #61