### PR TITLE
feat(config): Adds `Clone` to the `Config` type

### DIFF
--- a/crates/wasm-pkg-common/src/config.rs
+++ b/crates/wasm-pkg-common/src/config.rs
@@ -22,7 +22,7 @@ const DEFAULT_FALLBACK_NAMESPACE_REGISTRIES: &[(&str, &str)] = &[
 /// provide a consistent baseline user experience. Where needed, these defaults
 /// can be overridden with application-specific config via [`Config::merge`] or
 /// other mutation methods.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Config {
     default_registry: Option<Registry>,
     namespace_registries: HashMap<Label, Registry>,


### PR DESCRIPTION
We take an owned config to create a client, which is probably the correct design. Because of this, we should probably have it clonable so it is easier to use.

I did run into this when adding this to cargo component. We might also want to make `Client` clonable down the line, but for now this should work