### PR TITLE
fix(client): Implement various helpers for serialzing config structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3780,6 +3780,7 @@ dependencies = [
  "serde 1.0.201",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/crates/wasm-pkg-client/Cargo.toml
+++ b/crates/wasm-pkg-client/Cargo.toml
@@ -31,3 +31,6 @@ url = "2.5.0"
 warg-client = "0.7.0"
 warg-protocol = "0.7.0"
 wasm-pkg-common = { workspace = true, features = ["metadata-client", "tokio"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/wasm-pkg-client/src/warg/config.rs
+++ b/crates/wasm-pkg-client/src/warg/config.rs
@@ -7,7 +7,8 @@ use wasm_pkg_common::{config::RegistryConfig, Error};
 /// Registry configuration for Warg backends.
 ///
 /// See: [`RegistryConfig::backend_config`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(into = "WargRegistryConfigToml")]
 pub struct WargRegistryConfig {
     /// The configuration for the Warg client.
     pub client_config: warg_client::Config,
@@ -15,19 +16,6 @@ pub struct WargRegistryConfig {
     pub auth_token: Option<SecretString>,
     /// The path to the Warg config file, if specified.
     pub config_file: Option<PathBuf>,
-}
-
-impl Serialize for WargRegistryConfig {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        WargRegistryConfigToml {
-            auth_token: self.auth_token.clone(),
-            config_file: self.config_file.clone(),
-        }
-        .serialize(serializer)
-    }
 }
 
 impl TryFrom<&RegistryConfig> for WargRegistryConfig {
@@ -72,6 +60,15 @@ struct WargRegistryConfigToml {
         serialize_with = "serialize_secret"
     )]
     auth_token: Option<SecretString>,
+}
+
+impl From<WargRegistryConfig> for WargRegistryConfigToml {
+    fn from(value: WargRegistryConfig) -> Self {
+        WargRegistryConfigToml {
+            auth_token: value.auth_token,
+            config_file: value.config_file,
+        }
+    }
 }
 
 fn serialize_secret<S: Serializer>(

--- a/crates/wasm-pkg-client/src/warg/config.rs
+++ b/crates/wasm-pkg-client/src/warg/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use secrecy::SecretString;
-use serde::Deserialize;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize, Serializer};
 use wasm_pkg_common::{config::RegistryConfig, Error};
 
 /// Registry configuration for Warg backends.
@@ -9,8 +9,25 @@ use wasm_pkg_common::{config::RegistryConfig, Error};
 /// See: [`RegistryConfig::backend_config`]
 #[derive(Clone, Debug, Default)]
 pub struct WargRegistryConfig {
-    pub client_config: Option<warg_client::Config>,
+    /// The configuration for the Warg client.
+    pub client_config: warg_client::Config,
+    /// The authentication token for the Warg registry.
     pub auth_token: Option<SecretString>,
+    /// The path to the Warg config file, if specified.
+    pub config_file: Option<PathBuf>,
+}
+
+impl Serialize for WargRegistryConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        WargRegistryConfigToml {
+            auth_token: self.auth_token.clone(),
+            config_file: self.config_file.clone(),
+        }
+        .serialize(serializer)
+    }
 }
 
 impl TryFrom<&RegistryConfig> for WargRegistryConfig {
@@ -21,23 +38,105 @@ impl TryFrom<&RegistryConfig> for WargRegistryConfig {
             auth_token,
             config_file,
         } = registry_config.backend_config("warg")?.unwrap_or_default();
-        let client_config = match config_file {
-            Some(path) => Some(warg_client::Config::from_file(path).map_err(Error::RegistryError)?),
-            None => Some(
-                warg_client::Config::from_default_file()
-                    .map_err(Error::RegistryError)?
-                    .unwrap_or_default(),
+        let (client_config, config_file) = match config_file {
+            Some(path) => (
+                warg_client::Config::from_file(&path).map_err(Error::RegistryError)?,
+                Some(path),
             ),
+            None => {
+                // NOTE(thomastaylor312): We could try to be smarter here and see which file it
+                // loaded, but there isn't a way to do that if it loaded from the current working
+                // directory.
+                (
+                    warg_client::Config::from_default_file()
+                        .map_err(Error::RegistryError)?
+                        .unwrap_or_default(),
+                    None,
+                )
+            }
         };
         Ok(Self {
             client_config,
             auth_token,
+            config_file,
         })
     }
 }
 
-#[derive(Default, Deserialize)]
+#[derive(Default, Deserialize, Serialize)]
 struct WargRegistryConfigToml {
+    #[serde(skip_serializing_if = "Option::is_none")]
     config_file: Option<PathBuf>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_secret"
+    )]
     auth_token: Option<SecretString>,
+}
+
+fn serialize_secret<S: Serializer>(
+    secret: &Option<SecretString>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    if let Some(secret) = secret {
+        secret.expose_secret().serialize(serializer)
+    } else {
+        serializer.serialize_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_warg_config_roundtrip() {
+        let dir = tempfile::tempdir().expect("Unable to create tempdir");
+        let warg_config_path = dir.path().join("warg_config.json");
+        let config = WargRegistryConfig {
+            client_config: warg_client::Config {
+                home_url: Some("https://example.com".to_owned()),
+                ..Default::default()
+            },
+            auth_token: Some("imsecret".to_owned().into()),
+            config_file: Some(warg_config_path.clone()),
+        };
+
+        // Try loading it with the normal method to make sure it comes out right
+        let mut conf = crate::Config::empty();
+
+        let registry: crate::Registry = "example.com:8080".parse().unwrap();
+        let reg_conf = conf.get_or_insert_registry_config_mut(&registry);
+        reg_conf
+            .set_backend_config("warg", &config)
+            .expect("Unable to set config");
+
+        let reg_conf = conf.registry_config(&registry).unwrap();
+
+        // Write the warg config to disk
+        tokio::fs::write(
+            &warg_config_path,
+            serde_json::to_vec(&config.client_config).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let roundtripped = WargRegistryConfig::try_from(reg_conf).expect("Unable to load config");
+        assert_eq!(
+            roundtripped
+                .client_config
+                .home_url
+                .expect("Should have a home url set"),
+            config.client_config.home_url.unwrap(),
+            "Home url should be set to the right value"
+        );
+        assert_eq!(
+            roundtripped
+                .auth_token
+                .expect("Should have an auth token set")
+                .expose_secret(),
+            config.auth_token.unwrap().expose_secret(),
+            "Auth token should be set to the right value"
+        );
+    }
 }

--- a/crates/wasm-pkg-client/src/warg/mod.rs
+++ b/crates/wasm-pkg-client/src/warg/mod.rs
@@ -39,15 +39,9 @@ impl WargBackend {
         let WargRegistryConfig {
             client_config,
             auth_token,
+            ..
         } = registry_config.try_into()?;
 
-        let client_config = if let Some(client_config) = client_config {
-            client_config
-        } else {
-            warg_client::Config::from_default_file()
-                .map_err(Error::InvalidConfig)?
-                .unwrap_or_default()
-        };
         let client =
             FileSystemClient::new_with_config(Some(url.as_str()), &client_config, auth_token)
                 .await

--- a/crates/wasm-pkg-common/src/config.rs
+++ b/crates/wasm-pkg-common/src/config.rs
@@ -107,6 +107,13 @@ impl Config {
         Ok(toml_cfg.into())
     }
 
+    /// Writes the config to a TOML file at the given path.
+    pub fn to_file(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+        let toml_cfg = toml::TomlConfig::from(self.to_owned());
+        let toml_str = ::toml::to_string(&toml_cfg).map_err(Error::invalid_config)?;
+        std::fs::write(path, toml_str).map_err(Error::ConfigFileIoError)
+    }
+
     /// Merges the given other config into this one.
     pub fn merge(&mut self, other: Self) {
         let Self {

--- a/crates/wasm-pkg-common/src/config.rs
+++ b/crates/wasm-pkg-common/src/config.rs
@@ -22,7 +22,8 @@ const DEFAULT_FALLBACK_NAMESPACE_REGISTRIES: &[(&str, &str)] = &[
 /// provide a consistent baseline user experience. Where needed, these defaults
 /// can be overridden with application-specific config via [`Config::merge`] or
 /// other mutation methods.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(into = "toml::TomlConfig")]
 pub struct Config {
     default_registry: Option<Registry>,
     namespace_registries: HashMap<Label, Registry>,
@@ -109,8 +110,7 @@ impl Config {
 
     /// Writes the config to a TOML file at the given path.
     pub fn to_file(&self, path: impl AsRef<Path>) -> Result<(), Error> {
-        let toml_cfg = toml::TomlConfig::from(self.to_owned());
-        let toml_str = ::toml::to_string(&toml_cfg).map_err(Error::invalid_config)?;
+        let toml_str = ::toml::to_string(&self).map_err(Error::invalid_config)?;
         std::fs::write(path, toml_str).map_err(Error::ConfigFileIoError)
     }
 


### PR DESCRIPTION
Without these, it was basically impossible to serialize back to the intended config format expected