### PR TITLE
fix(common): Fixes issue where we couldn't get a backend type

### DIFF
--- a/crates/wasm-pkg-client/src/lib.rs
+++ b/crates/wasm-pkg-client/src/lib.rs
@@ -123,7 +123,7 @@ impl Client {
                 .unwrap_or_default();
 
             // Skip fetching metadata for "local" source
-            let should_fetch_meta = registry_config.backend_type() != Some("local");
+            let should_fetch_meta = registry_config.default_backend() != Some("local");
             let registry_meta = if should_fetch_meta {
                 RegistryMetadata::fetch_or_default(&registry).await
             } else {
@@ -131,7 +131,7 @@ impl Client {
             };
 
             // Resolve backend type
-            let backend_type = match registry_config.backend_type() {
+            let backend_type = match registry_config.default_backend() {
                 // If the local config specifies a backend type, use it
                 Some(backend_type) => Some(backend_type),
                 None => {

--- a/crates/wasm-pkg-common/Cargo.toml
+++ b/crates/wasm-pkg-common/Cargo.toml
@@ -22,7 +22,7 @@ semver = "1.0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.8"
-tokio = { workspace = true, features = ["io-util"], optional = true }
+tokio = { workspace = true, features = ["io-util", "fs"], optional = true }
 toml = "0.8.13"
 thiserror = "1.0"
 tracing = "0.1"


### PR DESCRIPTION
This fixes an issue where if you have a single backend type set, you still would get a None backend type. This meant that unless you explicitly specified a type, it would always resolve to OCI as used by the client.

This takes a middle ground approach that lets people write less toml. If an explicit type is not specified and only one type of config exists for a registry, then the backend type of that single config will be used instead. For more than one, you must specify a default.

Please note that I renamed this from `type` to `default` as that term better expresses the intent of what this config is doing. A user isn't specifying the type of config so much as the default backend config to use here in the (currently) unlikely case you have a registry that talks more than one protocol