### PR TITLE
Add a `repository` field to wkg's Cargo.toml.

### DIFF
--- a/crates/wkg/Cargo.toml
+++ b/crates/wkg/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "wkg"
 description = "Wasm Package Tools CLI"
+repository = "https://github.com/bytecodealliance/wasm-pkg-tools/tree/main/crates/wkg"
 edition.workspace = true
 version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
This will clarify that [the wkg crates.io page] corresponds to this repository.

[the wkg crates.io page]: https://crates.io/crates/wkg