### PR TITLE
feat(warg): Adds config option for signing secret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4004,6 +4004,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "warg-client",
+ "warg-crypto",
  "warg-protocol",
  "wasm-pkg-common",
  "wit-component 0.216.0",

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ default = "warg"
 # A path to a valid warg config file. If this is not set, the `wkg` CLI (but not the libraries) 
 # will attempt to load the config from the default location(s).
 config_file = "/a/path"
+# An optional authentication token to use when authenticating with a registry.
+auth_token = "an-auth-token"
+# An optional key for signing the component. Ideally, you should just let warg use the keychain
+# or programmatically set this key in the config without writing to disk. This offers an escape
+# hatch for when you need to use a key that isn't in the keychain.
+signing_key = "ecdsa-p256:2CV1EpLaSYEn4In4OAEDAj5O4Hzu8AFAxgHXuG310Ew="
 [registry."acme.registry.com".oci]
 # The auth field can either be a username/password pair, or a base64 encoded `username:password` 
 # string. If no auth is set, the `wkg` CLI (but not the libraries) will also attempt to load the

--- a/crates/wasm-pkg-client/Cargo.toml
+++ b/crates/wasm-pkg-client/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1.40"
 tracing-subscriber = { workspace = true }
 url = "2.5.0"
 warg-client = "0.8.0"
+warg-crypto = "0.8.0"
 warg-protocol = "0.8.0"
 wasm-pkg-common = { workspace = true, features = ["metadata-client", "tokio"] }
 wit-component = { workspace = true }

--- a/crates/wasm-pkg-client/src/warg/publisher.rs
+++ b/crates/wasm-pkg-client/src/warg/publisher.rs
@@ -39,10 +39,19 @@ impl PackagePublisher for WargBackend {
 
         // start Warg publish, using the keyring to sign
         let version = version.clone();
+        // Check if the package already exists so we can init it if needed
+        let release = PublishEntry::Release { version, content };
+        let entries = if let Err(warg_client::ClientError::PackageDoesNotExist { .. }) =
+            self.client.fetch_package(&name).await
+        {
+            vec![PublishEntry::Init, release]
+        } else {
+            vec![release]
+        };
         let info = PublishInfo {
             name: name.clone(),
             head: None,
-            entries: vec![PublishEntry::Release { version, content }],
+            entries,
         };
         let record_id = if let Some(key) = self.signing_key.as_ref() {
             self.client.publish_with_info(key, info).await


### PR DESCRIPTION
Adds and documents a new option for adding a signing key for publishing. This should enable additional flexibility in setting a signing key for tools like `cargo component`