### PR TITLE
chore(*): Bumps version and adds a step for autopublishing crates

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -101,3 +101,24 @@ jobs:
         shell: bash
         run: gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
       - run: gh release upload -R bytecodealliance/wasm-pkg-tools --clobber ${{ github.ref_name }} target/${{ matrix.rust-target }}/release/wkg-${{ matrix.rust-target }}
+  
+  publish_crates:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'bytecodealliance/wasm-pkg-tools'
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable --no-self-update && rustup default stable
+      - name: Publish wasm-pkg-common
+        working-directory: ./crates/wasm-pkg-common
+        run: cargo publish
+      - name: Publish wasm-pkg-client
+        working-directory: ./crates/wasm-pkg-client
+        run: cargo publish
+      - name: Publish wkg
+        working-directory: ./crates/wkg
+        run: cargo publish
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-client"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-common"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "wkg"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 
@@ -23,7 +23,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
     "fmt",
     "env-filter",
 ] }
-wasm-pkg-common = { version = "0.4.1", path = "crates/wasm-pkg-common" }
-wasm-pkg-client = { version = "0.4.1", path = "crates/wasm-pkg-client" }
+wasm-pkg-common = { version = "0.5.0", path = "crates/wasm-pkg-common" }
+wasm-pkg-client = { version = "0.5.0", path = "crates/wasm-pkg-client" }
 wit-component = "0.216"
 wit-parser = "0.216"

--- a/crates/wasm-pkg-common/src/digest.rs
+++ b/crates/wasm-pkg-common/src/digest.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "tokio")]
 use std::path::Path;
 use std::str::FromStr;
 


### PR DESCRIPTION
Also fixes a tiny warning that happened when the `tokio` feature was off.