### PR TITLE
chore(common): Switches default registry to wasi.dev for wasi namespace

### DIFF
--- a/crates/wasm-pkg-common/src/config.rs
+++ b/crates/wasm-pkg-common/src/config.rs
@@ -10,11 +10,8 @@ use crate::{label::Label, package::PackageRef, registry::Registry, Error};
 
 mod toml;
 
-const DEFAULT_FALLBACK_NAMESPACE_REGISTRIES: &[(&str, &str)] = &[
-    // TODO: Switch to wasi.dev once that is ready
-    ("wasi", "bytecodealliance.org"),
-    ("ba", "bytecodealliance.org"),
-];
+const DEFAULT_FALLBACK_NAMESPACE_REGISTRIES: &[(&str, &str)] =
+    &[("wasi", "wasi.dev"), ("ba", "bytecodealliance.org")];
 
 /// Wasm Package registry configuration.
 ///

--- a/crates/wkg-core/tests/fixtures/cli-example/wit/world.wit
+++ b/crates/wkg-core/tests/fixtures/cli-example/wit/world.wit
@@ -1,8 +1,8 @@
 package test:plugin;
 
 world plugin {
-  include wasi:cli/imports@0.2.0;
-  import wasi:http/outgoing-handler@0.2.0;
+  include wasi:cli/imports@0.2.1;
+  import wasi:http/outgoing-handler@0.2.1;
 
-  export wasi:cli/run@0.2.0;
+  export wasi:cli/run@0.2.1;
 }


### PR DESCRIPTION
I also updated one of the integration tests to use the 0.2.1 interfaces
so we could make sure that works as well