### PR TITLE
feat(client): Adds support for attaching annotations to manifests for OCI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
       - name: Run client tests
         working-directory: ./crates/wasm-pkg-client
         run: cargo test ${{ matrix.additional_test_flags }}
+      - name: Run wkg tests
+        working-directory: ./crates/wkg
+        run: cargo test ${{ matrix.additional_test_flags }}
       - name: Run other tests
-        run: cargo test --workspace --exclude wasm-pkg-client
+        run: cargo test --workspace --exclude wasm-pkg-client --exclude wkg
       - name: Run cargo clippy
         run: cargo clippy --all --workspace 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4430,6 +4430,7 @@ dependencies = [
  "warg-client",
  "warg-crypto",
  "warg-protocol",
+ "wasm-metadata 0.219.1",
  "wasm-pkg-common",
  "wit-component 0.219.1",
 ]
@@ -4916,6 +4917,7 @@ dependencies = [
  "oci-wasm",
  "serde_json",
  "tempfile",
+ "testcontainers",
  "tokio",
  "tokio-process",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 tempfile = "3.10.1"
+testcontainers = { version = "0.23" }
 thiserror = "1.0"
 tokio = "1.35.1"
 tokio-process = "0.2.5"

--- a/crates/wasm-pkg-client/Cargo.toml
+++ b/crates/wasm-pkg-client/Cargo.toml
@@ -36,10 +36,11 @@ tracing-subscriber = { workspace = true }
 url = "2.5.0"
 warg-client = "0.9.0"
 warg-crypto = "0.9.0"
+wasm-metadata = { workspace = true }
 warg-protocol = "0.9.0"
 wasm-pkg-common = { workspace = true, features = ["metadata-client", "tokio"] }
 wit-component = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
-testcontainers = "0.23"
+tempfile = { workspace = true }
+testcontainers = { workspace = true }

--- a/crates/wasm-pkg-client/src/oci/publisher.rs
+++ b/crates/wasm-pkg-client/src/oci/publisher.rs
@@ -1,5 +1,8 @@
+use std::collections::BTreeMap;
+
 use oci_client::{Reference, RegistryOperation};
 use tokio::io::AsyncReadExt;
+use wasm_metadata::LinkType;
 
 use crate::publisher::PackagePublisher;
 use crate::{PackageRef, PublishingSource, Version};
@@ -19,13 +22,50 @@ impl PackagePublisher for OciBackend {
         // to remove this and use the stream directly.
         let mut buf = Vec::new();
         data.read_to_end(&mut buf).await?;
+        let meta = wasm_metadata::RegistryMetadata::from_wasm(&buf).map_err(|e| {
+            crate::Error::InvalidComponent(anyhow::anyhow!("Unable to parse component: {e}"))
+        })?;
         let (config, layer) = oci_wasm::WasmConfig::from_raw_component(buf, None)
             .map_err(crate::Error::InvalidComponent)?;
+        let mut annotations = BTreeMap::from_iter([(
+            "org.opencontainers.image.version".to_string(),
+            version.to_string(),
+        )]);
+        if let Some(meta) = meta {
+            if let Some(desc) = meta.get_description() {
+                annotations.insert(
+                    "org.opencontainers.image.description".to_string(),
+                    desc.to_owned(),
+                );
+            }
+            if let Some(licenses) = meta.get_license() {
+                annotations.insert(
+                    "org.opencontainers.image.licenses".to_string(),
+                    licenses.to_owned(),
+                );
+            }
+            if let Some(sources) = meta.get_links() {
+                for link in sources {
+                    if link.ty == LinkType::Repository {
+                        annotations.insert(
+                            "org.opencontainers.image.source".to_string(),
+                            link.value.to_owned(),
+                        );
+                    }
+                    if link.ty == LinkType::Homepage {
+                        annotations.insert(
+                            "org.opencontainers.image.url".to_string(),
+                            link.value.to_owned(),
+                        );
+                    }
+                }
+            }
+        }
 
         let reference: Reference = self.make_reference(package, Some(version));
         let auth = self.auth(&reference, RegistryOperation::Push).await?;
         self.client
-            .push(&reference, &auth, layer, config, None)
+            .push(&reference, &auth, layer, config, Some(annotations))
             .await
             .map_err(crate::Error::RegistryError)?;
         Ok(())

--- a/crates/wkg/Cargo.toml
+++ b/crates/wkg/Cargo.toml
@@ -8,6 +8,11 @@ authors.workspace = true
 license.workspace = true
 readme = "../../README.md"
 
+[features]
+default = ["_local"]
+# An internal feature for making sure e2e tests can run locally but not in CI for Mac or Windows
+_local = []
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "wrap_help", "env"] }
@@ -29,3 +34,5 @@ wasm-pkg-core = { workspace = true }
 [dev-dependencies]
 base64 = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
+testcontainers = { workspace = true }

--- a/crates/wkg/tests/common.rs
+++ b/crates/wkg/tests/common.rs
@@ -1,0 +1,165 @@
+use std::{
+    collections::HashMap,
+    net::{Ipv4Addr, SocketAddrV4},
+    path::{Path, PathBuf},
+};
+
+use oci_client::client::ClientConfig;
+use testcontainers::{
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+    ContainerAsync, GenericImage, ImageExt,
+};
+use tokio::{net::TcpListener, process::Command};
+use wasm_pkg_client::{oci::OciRegistryConfig, Config, CustomConfig, Registry, RegistryMetadata};
+
+/// Returns an open port on localhost
+pub async fn find_open_port() -> u16 {
+    TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("failed to bind random port")
+        .local_addr()
+        .map(|addr| addr.port())
+        .expect("failed to get local address from opened TCP socket")
+}
+
+/// Starts a registry container on an open port, returning a [`Config`] with registry auth
+/// configured for it and the name of the registry. The container handle is also returned as it must
+/// be kept in scope
+pub async fn start_registry() -> (Config, Registry, ContainerAsync<GenericImage>) {
+    let port = find_open_port().await;
+    let container = GenericImage::new("registry", "2")
+        .with_wait_for(WaitFor::message_on_stderr("listening on [::]:5000"))
+        .with_mapped_port(port, 5000.tcp())
+        .start()
+        .await
+        .expect("Failed to start test container");
+
+    let registry: Registry = format!("localhost:{}", port).parse().unwrap();
+    let mut config = Config::empty();
+    // Make sure we add wasi. The default fallbacks don't get written to disk, which we use in
+    // tests, so we just start with an empty config and write this into it
+    config.set_namespace_registry(
+        "wasi".parse().unwrap(),
+        wasm_pkg_client::RegistryMapping::Registry("wasi.dev".parse().unwrap()),
+    );
+    let reg_conf = config.get_or_insert_registry_config_mut(&registry);
+    reg_conf
+        .set_backend_config(
+            "oci",
+            OciRegistryConfig {
+                client_config: ClientConfig {
+                    protocol: oci_client::client::ClientProtocol::Http,
+                    ..Default::default()
+                },
+                credentials: None,
+            },
+        )
+        .unwrap();
+
+    (config, registry, container)
+}
+
+/// Clones the given config, mapping the namespace to the given registry at the top level
+pub fn map_namespace(config: &Config, namespace: &str, registry: &Registry) -> Config {
+    let mut config = config.clone();
+    let mut metadata = RegistryMetadata::default();
+    metadata.preferred_protocol = Some("oci".to_string());
+    let mut meta = serde_json::Map::new();
+    meta.insert("registry".to_string(), registry.to_string().into());
+    metadata.protocol_configs = HashMap::from_iter([("oci".to_string(), meta)]);
+    config.set_namespace_registry(
+        namespace.parse().unwrap(),
+        wasm_pkg_client::RegistryMapping::Custom(CustomConfig {
+            registry: registry.to_owned(),
+            metadata,
+        }),
+    );
+    config
+}
+
+/// A loaded fixture with helpers for running wkg tests
+pub struct Fixture {
+    pub temp_dir: tempfile::TempDir,
+    pub fixture_path: PathBuf,
+}
+
+impl Fixture {
+    /// Returns a base `wkg` command for running tests with the current directory set to the loaded
+    /// fixture and with a separate wkg cache dir
+    pub fn command(&self) -> Command {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_wkg"));
+        cmd.current_dir(&self.fixture_path);
+        cmd.env("WKG_CACHE_DIR", self.temp_dir.path().join("cache"));
+        cmd
+    }
+
+    /// Same as [`Fixture::command`] but also writes the given config to disk and sets the
+    /// `WKG_CONFIG` environment variable to the path of the config
+    pub async fn command_with_config(&self, config: &Config) -> Command {
+        let config_path = self.temp_dir.path().join("config.toml");
+        config
+            .to_file(&config_path)
+            .await
+            .expect("failed to write config");
+        let mut cmd = self.command();
+        cmd.env("WKG_CONFIG_FILE", config_path);
+        cmd
+    }
+}
+
+/// Gets the path to the fixture
+pub fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}
+
+/// Loads the fixture with the given name into a temporary directory. This will copy the fixture
+/// from the tests/fixtures directory into a temporary directory and return the tempdir containing
+/// that directory (and its path)
+pub async fn load_fixture(fixture: &str) -> Fixture {
+    let temp_dir = tempfile::tempdir().expect("Failed to create tempdir");
+    let fixture_path = fixture_dir().join(fixture);
+    // This will error if it doesn't exist, which is what we want
+    tokio::fs::metadata(&fixture_path)
+        .await
+        .expect("Fixture does not exist or couldn't be read");
+    let copied_path = temp_dir.path().join(fixture_path.file_name().unwrap());
+    copy_dir(&fixture_path, &copied_path)
+        .await
+        .expect("Failed to copy fixture");
+    Fixture {
+        temp_dir,
+        fixture_path: copied_path,
+    }
+}
+
+#[allow(dead_code)]
+async fn copy_dir(source: impl AsRef<Path>, destination: impl AsRef<Path>) -> anyhow::Result<()> {
+    tokio::fs::create_dir_all(&destination).await?;
+    let mut entries = tokio::fs::read_dir(source).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let filetype = entry.file_type().await?;
+        if filetype.is_dir() {
+            // Skip the deps directory in case it is there from debugging
+            if entry.path().file_name().unwrap_or_default() == "deps" {
+                continue;
+            }
+            Box::pin(copy_dir(
+                entry.path(),
+                destination.as_ref().join(entry.file_name()),
+            ))
+            .await?;
+        } else {
+            let path = entry.path();
+            let extension = path.extension().unwrap_or_default();
+            // Skip any .lock files that might be there from debugging
+            if extension == "lock" {
+                continue;
+            }
+            tokio::fs::copy(path, destination.as_ref().join(entry.file_name())).await?;
+        }
+    }
+    Ok(())
+}

--- a/crates/wkg/tests/e2e.rs
+++ b/crates/wkg/tests/e2e.rs
@@ -1,0 +1,89 @@
+mod common;
+
+#[cfg(any(target_os = "linux", feature = "_local"))]
+// NOTE: These are only run on linux for CI purposes, because they rely on the docker client being
+// available, and for various reasons this has proven to be problematic on both the Windows and
+// MacOS runners due to it not being installed (yay licensing).
+#[tokio::test]
+async fn build_and_publish_with_metadata() {
+    use oci_client::{client::ClientConfig, manifest::OciManifest, Reference};
+
+    let (config, registry, _container) = common::start_registry().await;
+
+    let fixture = common::load_fixture("wasi-http").await;
+
+    let status = fixture
+        .command_with_config(&config)
+        .await
+        .args(["wit", "build"])
+        .status()
+        .await
+        .expect("Should be able to build wit packagee");
+    assert!(status.success(), "Build should succeed");
+
+    let namespace_mapped_config = common::map_namespace(&config, "wasi", &registry);
+    let status = fixture
+        .command_with_config(&namespace_mapped_config)
+        .await
+        .args(["publish", "wasi:http@0.2.0.wasm"])
+        .status()
+        .await
+        .expect("Should be able to publish wit package");
+    assert!(status.success(), "Publish should succeed");
+
+    // Now fetch the manifest and verify the annotations are present
+    let client = oci_client::Client::new(ClientConfig {
+        protocol: oci_client::client::ClientProtocol::Http,
+        ..Default::default()
+    });
+
+    let reference: Reference = format!("{registry}/wasi/http:0.2.0").parse().unwrap();
+    let (manifest, _) = client
+        .pull_manifest(&reference, &oci_client::secrets::RegistryAuth::Anonymous)
+        .await
+        .expect("Should be able to fetch manifest");
+
+    let manifest = if let OciManifest::Image(m) = manifest {
+        m
+    } else {
+        panic!("Manifest should be an image manifest");
+    };
+
+    let annotations = manifest
+        .annotations
+        .expect("Manifest should have annotations");
+
+    let wkg_toml =
+        wasm_pkg_core::config::Config::load_from_path(fixture.fixture_path.join("wkg.toml"))
+            .await
+            .expect("Should be able to load wkg.toml");
+    let meta = wkg_toml.metadata.expect("Should have metadata");
+
+    assert_eq!(
+        annotations
+            .get("org.opencontainers.image.version")
+            .expect("Should have version"),
+        "0.2.0",
+        "Version should be 0.2.0"
+    );
+    assert_eq!(
+        annotations.get("org.opencontainers.image.description"),
+        meta.description.as_ref(),
+        "Description should match"
+    );
+    assert_eq!(
+        annotations.get("org.opencontainers.image.licenses"),
+        meta.license.as_ref(),
+        "License should match"
+    );
+    assert_eq!(
+        annotations.get("org.opencontainers.image.source"),
+        meta.repository.as_ref(),
+        "Source should match"
+    );
+    assert_eq!(
+        annotations.get("org.opencontainers.image.url"),
+        meta.homepage.as_ref(),
+        "Name should match"
+    );
+}

--- a/crates/wkg/tests/fixtures/wasi-http/.gitignore
+++ b/crates/wkg/tests/fixtures/wasi-http/.gitignore
@@ -1,0 +1,2 @@
+wkg.lock
+deps/

--- a/crates/wkg/tests/fixtures/wasi-http/wit/handler.wit
+++ b/crates/wkg/tests/fixtures/wasi-http/wit/handler.wit
@@ -1,0 +1,43 @@
+/// This interface defines a handler of incoming HTTP Requests. It should
+/// be exported by components which can respond to HTTP Requests.
+interface incoming-handler {
+  use types.{incoming-request, response-outparam};
+
+  /// This function is invoked with an incoming HTTP Request, and a resource
+  /// `response-outparam` which provides the capability to reply with an HTTP
+  /// Response. The response is sent by calling the `response-outparam.set`
+  /// method, which allows execution to continue after the response has been
+  /// sent. This enables both streaming to the response body, and performing other
+  /// work.
+  ///
+  /// The implementor of this function must write a response to the
+  /// `response-outparam` before returning, or else the caller will respond
+  /// with an error on its behalf.
+  handle: func(
+    request: incoming-request,
+    response-out: response-outparam
+  );
+}
+
+/// This interface defines a handler of outgoing HTTP Requests. It should be
+/// imported by components which wish to make HTTP Requests.
+interface outgoing-handler {
+  use types.{
+    outgoing-request, request-options, future-incoming-response, error-code
+  };
+
+  /// This function is invoked with an outgoing HTTP Request, and it returns
+  /// a resource `future-incoming-response` which represents an HTTP Response
+  /// which may arrive in the future.
+  ///
+  /// The `options` argument accepts optional parameters for the HTTP
+  /// protocol's transport layer.
+  ///
+  /// This function may return an error if the `outgoing-request` is invalid
+  /// or not allowed to be made. Otherwise, protocol errors are reported
+  /// through the `future-incoming-response`.
+  handle: func(
+    request: outgoing-request,
+    options: option<request-options>
+  ) -> result<future-incoming-response, error-code>;
+}

--- a/crates/wkg/tests/fixtures/wasi-http/wit/proxy.wit
+++ b/crates/wkg/tests/fixtures/wasi-http/wit/proxy.wit
@@ -1,0 +1,32 @@
+package wasi:http@0.2.0;
+
+/// The `wasi:http/proxy` world captures a widely-implementable intersection of
+/// hosts that includes HTTP forward and reverse proxies. Components targeting
+/// this world may concurrently stream in and out any number of incoming and
+/// outgoing HTTP requests.
+world proxy {
+  /// HTTP proxies have access to time and randomness.
+  include wasi:clocks/imports@0.2.0;
+  import wasi:random/random@0.2.0;
+
+  /// Proxies have standard output and error streams which are expected to
+  /// terminate in a developer-facing console provided by the host.
+  import wasi:cli/stdout@0.2.0;
+  import wasi:cli/stderr@0.2.0;
+
+  /// TODO: this is a temporary workaround until component tooling is able to
+  /// gracefully handle the absence of stdin. Hosts must return an eof stream
+  /// for this import, which is what wasi-libc + tooling will do automatically
+  /// when this import is properly removed.
+  import wasi:cli/stdin@0.2.0;
+
+  /// This is the default handler to use when user code simply wants to make an
+  /// HTTP request (e.g., via `fetch()`).
+  import outgoing-handler;
+
+  /// The host delivers incoming HTTP requests to a component by calling the
+  /// `handle` function of this exported interface. A host may arbitrarily reuse
+  /// or not reuse component instance when delivering incoming HTTP requests and
+  /// thus a component must be able to handle 0..N calls to `handle`.
+  export incoming-handler;
+}

--- a/crates/wkg/tests/fixtures/wasi-http/wit/types.wit
+++ b/crates/wkg/tests/fixtures/wasi-http/wit/types.wit
@@ -1,0 +1,570 @@
+/// This interface defines all of the types and methods for implementing
+/// HTTP Requests and Responses, both incoming and outgoing, as well as
+/// their headers, trailers, and bodies.
+interface types {
+  use wasi:clocks/monotonic-clock@0.2.0.{duration};
+  use wasi:io/streams@0.2.0.{input-stream, output-stream};
+  use wasi:io/error@0.2.0.{error as io-error};
+  use wasi:io/poll@0.2.0.{pollable};
+
+  /// This type corresponds to HTTP standard Methods.
+  variant method {
+    get,
+    head,
+    post,
+    put,
+    delete,
+    connect,
+    options,
+    trace,
+    patch,
+    other(string)
+  }
+
+  /// This type corresponds to HTTP standard Related Schemes.
+  variant scheme {
+    HTTP,
+    HTTPS,
+    other(string)
+  }
+
+  /// These cases are inspired by the IANA HTTP Proxy Error Types:
+  ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  variant error-code {
+    DNS-timeout,
+    DNS-error(DNS-error-payload),
+    destination-not-found,
+    destination-unavailable,
+    destination-IP-prohibited,
+    destination-IP-unroutable,
+    connection-refused,
+    connection-terminated,
+    connection-timeout,
+    connection-read-timeout,
+    connection-write-timeout,
+    connection-limit-reached,
+    TLS-protocol-error,
+    TLS-certificate-error,
+    TLS-alert-received(TLS-alert-received-payload),
+    HTTP-request-denied,
+    HTTP-request-length-required,
+    HTTP-request-body-size(option<u64>),
+    HTTP-request-method-invalid,
+    HTTP-request-URI-invalid,
+    HTTP-request-URI-too-long,
+    HTTP-request-header-section-size(option<u32>),
+    HTTP-request-header-size(option<field-size-payload>),
+    HTTP-request-trailer-section-size(option<u32>),
+    HTTP-request-trailer-size(field-size-payload),
+    HTTP-response-incomplete,
+    HTTP-response-header-section-size(option<u32>),
+    HTTP-response-header-size(field-size-payload),
+    HTTP-response-body-size(option<u64>),
+    HTTP-response-trailer-section-size(option<u32>),
+    HTTP-response-trailer-size(field-size-payload),
+    HTTP-response-transfer-coding(option<string>),
+    HTTP-response-content-coding(option<string>),
+    HTTP-response-timeout,
+    HTTP-upgrade-failed,
+    HTTP-protocol-error,
+    loop-detected,
+    configuration-error,
+    /// This is a catch-all error for anything that doesn't fit cleanly into a
+    /// more specific case. It also includes an optional string for an
+    /// unstructured description of the error. Users should not depend on the
+    /// string for diagnosing errors, as it's not required to be consistent
+    /// between implementations.
+    internal-error(option<string>)
+  }
+
+  /// Defines the case payload type for `DNS-error` above:
+  record DNS-error-payload {
+    rcode: option<string>,
+    info-code: option<u16>
+  }
+
+  /// Defines the case payload type for `TLS-alert-received` above:
+  record TLS-alert-received-payload {
+    alert-id: option<u8>,
+    alert-message: option<string>
+  }
+
+  /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+  record field-size-payload {
+    field-name: option<string>,
+    field-size: option<u32>
+  }
+
+  /// Attempts to extract a http-related `error` from the wasi:io `error`
+  /// provided.
+  ///
+  /// Stream operations which return
+  /// `wasi:io/stream/stream-error::last-operation-failed` have a payload of
+  /// type `wasi:io/error/error` with more information about the operation
+  /// that failed. This payload can be passed through to this function to see
+  /// if there's http-related information about the error to return.
+  ///
+  /// Note that this function is fallible because not all io-errors are
+  /// http-related errors.
+  http-error-code: func(err: borrow<io-error>) -> option<error-code>;
+
+  /// This type enumerates the different kinds of errors that may occur when
+  /// setting or appending to a `fields` resource.
+  variant header-error {
+    /// This error indicates that a `field-key` or `field-value` was
+    /// syntactically invalid when used with an operation that sets headers in a
+    /// `fields`.
+    invalid-syntax,
+
+    /// This error indicates that a forbidden `field-key` was used when trying
+    /// to set a header in a `fields`.
+    forbidden,
+
+    /// This error indicates that the operation on the `fields` was not
+    /// permitted because the fields are immutable.
+    immutable,
+  }
+
+  /// Field keys are always strings.
+  type field-key = string;
+
+  /// Field values should always be ASCII strings. However, in
+  /// reality, HTTP implementations often have to interpret malformed values,
+  /// so they are provided as a list of bytes.
+  type field-value = list<u8>;
+
+  /// This following block defines the `fields` resource which corresponds to
+  /// HTTP standard Fields. Fields are a common representation used for both
+  /// Headers and Trailers.
+  ///
+  /// A `fields` may be mutable or immutable. A `fields` created using the
+  /// constructor, `from-list`, or `clone` will be mutable, but a `fields`
+  /// resource given by other means (including, but not limited to,
+  /// `incoming-request.headers`, `outgoing-request.headers`) might be be
+  /// immutable. In an immutable fields, the `set`, `append`, and `delete`
+  /// operations will fail with `header-error.immutable`.
+  resource fields {
+
+    /// Construct an empty HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
+    constructor();
+
+    /// Construct an HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
+    ///
+    /// The list represents each key-value pair in the Fields. Keys
+    /// which have multiple values are represented by multiple entries in this
+    /// list with the same key.
+    ///
+    /// The tuple is a pair of the field key, represented as a string, and
+    /// Value, represented as a list of bytes. In a valid Fields, all keys
+    /// and values are valid UTF-8 strings. However, values are not always
+    /// well-formed, so they are represented as a raw list of bytes.
+    ///
+    /// An error result will be returned if any header or value was
+    /// syntactically invalid, or if a header was forbidden.
+    from-list: static func(
+      entries: list<tuple<field-key,field-value>>
+    ) -> result<fields, header-error>;
+
+    /// Get all of the values corresponding to a key. If the key is not present
+    /// in this `fields`, an empty list is returned. However, if the key is
+    /// present but empty, this is represented by a list with one or more
+    /// empty field-values present.
+    get: func(name: field-key) -> list<field-value>;
+
+    /// Returns `true` when the key is present in this `fields`. If the key is
+    /// syntactically invalid, `false` is returned.
+    has: func(name: field-key) -> bool;
+
+    /// Set all of the values for a key. Clears any existing values for that
+    /// key, if they have been set.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
+    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
+
+    /// Delete all values for a key. Does nothing if no values for the key
+    /// exist.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
+    delete: func(name: field-key) -> result<_, header-error>;
+
+    /// Append a value for a key. Does not change or delete any existing
+    /// values for that key.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
+    append: func(name: field-key, value: field-value) -> result<_, header-error>;
+
+    /// Retrieve the full set of keys and values in the Fields. Like the
+    /// constructor, the list represents each key-value pair.
+    ///
+    /// The outer list represents each key-value pair in the Fields. Keys
+    /// which have multiple values are represented by multiple entries in this
+    /// list with the same key.
+    entries: func() -> list<tuple<field-key,field-value>>;
+
+    /// Make a deep copy of the Fields. Equivelant in behavior to calling the
+    /// `fields` constructor on the return value of `entries`. The resulting
+    /// `fields` is mutable.
+    clone: func() -> fields;
+  }
+
+  /// Headers is an alias for Fields.
+  type headers = fields;
+
+  /// Trailers is an alias for Fields.
+  type trailers = fields;
+
+  /// Represents an incoming HTTP Request.
+  resource incoming-request {
+
+    /// Returns the method of the incoming request.
+    method: func() -> method;
+
+    /// Returns the path with query parameters from the request, as a string.
+    path-with-query: func() -> option<string>;
+
+    /// Returns the protocol scheme from the request.
+    scheme: func() -> option<scheme>;
+
+    /// Returns the authority from the request, if it was present.
+    authority: func() -> option<string>;
+
+    /// Get the `headers` associated with the request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// The `headers` returned are a child resource: it must be dropped before
+    /// the parent `incoming-request` is dropped. Dropping this
+    /// `incoming-request` before all children are dropped will trap.
+    headers: func() -> headers;
+
+    /// Gives the `incoming-body` associated with this request. Will only
+    /// return success at most once, and subsequent calls will return error.
+    consume: func() -> result<incoming-body>;
+  }
+
+  /// Represents an outgoing HTTP Request.
+  resource outgoing-request {
+
+    /// Construct a new `outgoing-request` with a default `method` of `GET`, and
+    /// `none` values for `path-with-query`, `scheme`, and `authority`.
+    ///
+    /// * `headers` is the HTTP Headers for the Request.
+    ///
+    /// It is possible to construct, or manipulate with the accessor functions
+    /// below, an `outgoing-request` with an invalid combination of `scheme`
+    /// and `authority`, or `headers` which are not permitted to be sent.
+    /// It is the obligation of the `outgoing-handler.handle` implementation
+    /// to reject invalid constructions of `outgoing-request`.
+    constructor(
+      headers: headers
+    );
+
+    /// Returns the resource corresponding to the outgoing Body for this
+    /// Request.
+    ///
+    /// Returns success on the first call: the `outgoing-body` resource for
+    /// this `outgoing-request` can be retrieved at most once. Subsequent
+    /// calls will return error.
+    body: func() -> result<outgoing-body>;
+
+    /// Get the Method for the Request.
+    method: func() -> method;
+    /// Set the Method for the Request. Fails if the string present in a
+    /// `method.other` argument is not a syntactically valid method.
+    set-method: func(method: method) -> result;
+
+    /// Get the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query.
+    path-with-query: func() -> option<string>;
+    /// Set the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query. Fails is the
+    /// string given is not a syntactically valid path and query uri component.
+    set-path-with-query: func(path-with-query: option<string>) -> result;
+
+    /// Get the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme.
+    scheme: func() -> option<scheme>;
+    /// Set the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme. Fails if the
+    /// string given is not a syntactically valid uri scheme.
+    set-scheme: func(scheme: option<scheme>) -> result;
+
+    /// Get the HTTP Authority for the Request. A value of `none` may be used
+    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// HTTPS schemes always require an authority.
+    authority: func() -> option<string>;
+    /// Set the HTTP Authority for the Request. A value of `none` may be used
+    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// HTTPS schemes always require an authority. Fails if the string given is
+    /// not a syntactically valid uri authority.
+    set-authority: func(authority: option<string>) -> result;
+
+    /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// another component by e.g. `outgoing-handler.handle`.
+    headers: func() -> headers;
+  }
+
+  /// Parameters for making an HTTP Request. Each of these parameters is
+  /// currently an optional timeout applicable to the transport layer of the
+  /// HTTP protocol.
+  ///
+  /// These timeouts are separate from any the user may use to bound a
+  /// blocking call to `wasi:io/poll.poll`.
+  resource request-options {
+    /// Construct a default `request-options` value.
+    constructor();
+
+    /// The timeout for the initial connect to the HTTP Server.
+    connect-timeout: func() -> option<duration>;
+
+    /// Set the timeout for the initial connect to the HTTP Server. An error
+    /// return value indicates that this timeout is not supported.
+    set-connect-timeout: func(duration: option<duration>) -> result;
+
+    /// The timeout for receiving the first byte of the Response body.
+    first-byte-timeout: func() -> option<duration>;
+
+    /// Set the timeout for receiving the first byte of the Response body. An
+    /// error return value indicates that this timeout is not supported.
+    set-first-byte-timeout: func(duration: option<duration>) -> result;
+
+    /// The timeout for receiving subsequent chunks of bytes in the Response
+    /// body stream.
+    between-bytes-timeout: func() -> option<duration>;
+
+    /// Set the timeout for receiving subsequent chunks of bytes in the Response
+    /// body stream. An error return value indicates that this timeout is not
+    /// supported.
+    set-between-bytes-timeout: func(duration: option<duration>) -> result;
+  }
+
+  /// Represents the ability to send an HTTP Response.
+  ///
+  /// This resource is used by the `wasi:http/incoming-handler` interface to
+  /// allow a Response to be sent corresponding to the Request provided as the
+  /// other argument to `incoming-handler.handle`.
+  resource response-outparam {
+
+    /// Set the value of the `response-outparam` to either send a response,
+    /// or indicate an error.
+    ///
+    /// This method consumes the `response-outparam` to ensure that it is
+    /// called at most once. If it is never called, the implementation
+    /// will respond with an error.
+    ///
+    /// The user may provide an `error` to `response` to allow the
+    /// implementation determine how to respond with an HTTP error response.
+    set: static func(
+      param: response-outparam,
+      response: result<outgoing-response, error-code>,
+    );
+  }
+
+  /// This type corresponds to the HTTP standard Status Code.
+  type status-code = u16;
+
+  /// Represents an incoming HTTP Response.
+  resource incoming-response {
+
+    /// Returns the status code from the incoming response.
+    status: func() -> status-code;
+
+    /// Returns the headers from the incoming response.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `incoming-response` is dropped.
+    headers: func() -> headers;
+
+    /// Returns the incoming body. May be called at most once. Returns error
+    /// if called additional times.
+    consume: func() -> result<incoming-body>;
+  }
+
+  /// Represents an incoming HTTP Request or Response's Body.
+  ///
+  /// A body has both its contents - a stream of bytes - and a (possibly
+  /// empty) set of trailers, indicating that the full contents of the
+  /// body have been received. This resource represents the contents as
+  /// an `input-stream` and the delivery of trailers as a `future-trailers`,
+  /// and ensures that the user of this interface may only be consuming either
+  /// the body contents or waiting on trailers at any given time.
+  resource incoming-body {
+
+    /// Returns the contents of the body, as a stream of bytes.
+    ///
+    /// Returns success on first call: the stream representing the contents
+    /// can be retrieved at most once. Subsequent calls will return error.
+    ///
+    /// The returned `input-stream` resource is a child: it must be dropped
+    /// before the parent `incoming-body` is dropped, or consumed by
+    /// `incoming-body.finish`.
+    ///
+    /// This invariant ensures that the implementation can determine whether
+    /// the user is consuming the contents of the body, waiting on the
+    /// `future-trailers` to be ready, or neither. This allows for network
+    /// backpressure is to be applied when the user is consuming the body,
+    /// and for that backpressure to not inhibit delivery of the trailers if
+    /// the user does not read the entire body.
+    %stream: func() -> result<input-stream>;
+
+    /// Takes ownership of `incoming-body`, and returns a `future-trailers`.
+    /// This function will trap if the `input-stream` child is still alive.
+    finish: static func(this: incoming-body) -> future-trailers;
+  }
+
+  /// Represents a future which may eventaully return trailers, or an error.
+  ///
+  /// In the case that the incoming HTTP Request or Response did not have any
+  /// trailers, this future will resolve to the empty set of trailers once the
+  /// complete Request or Response body has been received.
+  resource future-trailers {
+
+    /// Returns a pollable which becomes ready when either the trailers have
+    /// been received, or an error has occured. When this pollable is ready,
+    /// the `get` method will return `some`.
+    subscribe: func() -> pollable;
+
+    /// Returns the contents of the trailers, or an error which occured,
+    /// once the future is ready.
+    ///
+    /// The outer `option` represents future readiness. Users can wait on this
+    /// `option` to become `some` using the `subscribe` method.
+    ///
+    /// The outer `result` is used to retrieve the trailers or error at most
+    /// once. It will be success on the first call in which the outer option
+    /// is `some`, and error on subsequent calls.
+    ///
+    /// The inner `result` represents that either the HTTP Request or Response
+    /// body, as well as any trailers, were received successfully, or that an
+    /// error occured receiving them. The optional `trailers` indicates whether
+    /// or not trailers were present in the body.
+    ///
+    /// When some `trailers` are returned by this method, the `trailers`
+    /// resource is immutable, and a child. Use of the `set`, `append`, or
+    /// `delete` methods will return an error, and the resource must be
+    /// dropped before the parent `future-trailers` is dropped.
+    get: func() -> option<result<result<option<trailers>, error-code>>>;
+  }
+
+  /// Represents an outgoing HTTP Response.
+  resource outgoing-response {
+
+    /// Construct an `outgoing-response`, with a default `status-code` of `200`.
+    /// If a different `status-code` is needed, it must be set via the
+    /// `set-status-code` method.
+    ///
+    /// * `headers` is the HTTP Headers for the Response.
+    constructor(headers: headers);
+
+    /// Get the HTTP Status Code for the Response.
+    status-code: func() -> status-code;
+
+    /// Set the HTTP Status Code for the Response. Fails if the status-code
+    /// given is not a valid http status code.
+    set-status-code: func(status-code: status-code) -> result;
+
+    /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// another component by e.g. `outgoing-handler.handle`.
+    headers: func() -> headers;
+
+    /// Returns the resource corresponding to the outgoing Body for this Response.
+    ///
+    /// Returns success on the first call: the `outgoing-body` resource for
+    /// this `outgoing-response` can be retrieved at most once. Subsequent
+    /// calls will return error.
+    body: func() -> result<outgoing-body>;
+  }
+
+  /// Represents an outgoing HTTP Request or Response's Body.
+  ///
+  /// A body has both its contents - a stream of bytes - and a (possibly
+  /// empty) set of trailers, inducating the full contents of the body
+  /// have been sent. This resource represents the contents as an
+  /// `output-stream` child resource, and the completion of the body (with
+  /// optional trailers) with a static function that consumes the
+  /// `outgoing-body` resource, and ensures that the user of this interface
+  /// may not write to the body contents after the body has been finished.
+  ///
+  /// If the user code drops this resource, as opposed to calling the static
+  /// method `finish`, the implementation should treat the body as incomplete,
+  /// and that an error has occured. The implementation should propogate this
+  /// error to the HTTP protocol by whatever means it has available,
+  /// including: corrupting the body on the wire, aborting the associated
+  /// Request, or sending a late status code for the Response.
+  resource outgoing-body {
+
+    /// Returns a stream for writing the body contents.
+    ///
+    /// The returned `output-stream` is a child resource: it must be dropped
+    /// before the parent `outgoing-body` resource is dropped (or finished),
+    /// otherwise the `outgoing-body` drop or `finish` will trap.
+    ///
+    /// Returns success on the first call: the `output-stream` resource for
+    /// this `outgoing-body` may be retrieved at most once. Subsequent calls
+    /// will return error.
+    write: func() -> result<output-stream>;
+
+    /// Finalize an outgoing body, optionally providing trailers. This must be
+    /// called to signal that the response is complete. If the `outgoing-body`
+    /// is dropped without calling `outgoing-body.finalize`, the implementation
+    /// should treat the body as corrupted.
+    ///
+    /// Fails if the body's `outgoing-request` or `outgoing-response` was
+    /// constructed with a Content-Length header, and the contents written
+    /// to the body (via `write`) does not match the value given in the
+    /// Content-Length.
+    finish: static func(
+      this: outgoing-body,
+      trailers: option<trailers>
+    ) -> result<_, error-code>;
+  }
+
+  /// Represents a future which may eventaully return an incoming HTTP
+  /// Response, or an error.
+  ///
+  /// This resource is returned by the `wasi:http/outgoing-handler` interface to
+  /// provide the HTTP Response corresponding to the sent Request.
+  resource future-incoming-response {
+    /// Returns a pollable which becomes ready when either the Response has
+    /// been received, or an error has occured. When this pollable is ready,
+    /// the `get` method will return `some`.
+    subscribe: func() -> pollable;
+
+    /// Returns the incoming HTTP Response, or an error, once one is ready.
+    ///
+    /// The outer `option` represents future readiness. Users can wait on this
+    /// `option` to become `some` using the `subscribe` method.
+    ///
+    /// The outer `result` is used to retrieve the response or error at most
+    /// once. It will be success on the first call in which the outer option
+    /// is `some`, and error on subsequent calls.
+    ///
+    /// The inner `result` represents that either the incoming HTTP Response
+    /// status and headers have recieved successfully, or that an error
+    /// occured. Errors may also occur while consuming the response body,
+    /// but those will be reported by the `incoming-body` and its
+    /// `output-stream` child.
+    get: func() -> option<result<result<incoming-response, error-code>>>;
+
+  }
+}

--- a/crates/wkg/tests/fixtures/wasi-http/wkg.toml
+++ b/crates/wkg/tests/fixtures/wasi-http/wkg.toml
@@ -1,0 +1,8 @@
+[metadata]
+authors = ["WasmPkg <wasm-pkg@bytecodealliance.org>"]
+categories = ["wasm-pkg"]
+description = "WASI HTTP interface"
+license = "Apache-2.0"
+documentation = "https://docs.foobar.baz"
+homepage = "https://foobar.baz"
+repository = "https://github.com/bytecodealliance/wasm-pkg-tools"


### PR DESCRIPTION
This maps the metadata within a component (if it is present) to the appropriate annotations on the manifest. This also sets up some basic testing helpers for wkg e2e tests