### PR TITLE
fix(core): allow transitive fetching local deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,6 +2121,12 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -3708,6 +3724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",

--- a/crates/wasm-pkg-core/tests/fixtures/transitive-local/example-a/wit/world.wit
+++ b/crates/wasm-pkg-core/tests/fixtures/transitive-local/example-a/wit/world.wit
@@ -1,0 +1,12 @@
+package example-a:foo@0.1.0;
+
+interface foo {
+  record request {
+    foo: list<u8>,
+  }
+}
+
+world handler {
+  import example-b:bar/bar@0.1.0;
+  export foo;
+}

--- a/crates/wasm-pkg-core/tests/fixtures/transitive-local/example-b/wit/world.wit
+++ b/crates/wasm-pkg-core/tests/fixtures/transitive-local/example-b/wit/world.wit
@@ -1,0 +1,12 @@
+package example-b:bar@0.1.0;
+
+interface bar {
+  record response {
+    bar: list<u8>,
+  }
+}
+
+world handler {
+  import example-c:baz/baz@0.1.0;
+  export bar;
+}

--- a/crates/wasm-pkg-core/tests/fixtures/transitive-local/example-c/wit/world.wit
+++ b/crates/wasm-pkg-core/tests/fixtures/transitive-local/example-c/wit/world.wit
@@ -1,0 +1,12 @@
+package example-c:baz@0.1.0;
+
+interface baz {
+  record requestresponse {
+    baz: list<u8>,
+  }
+}
+
+world handler {
+  // No dependencies to import
+  export baz;
+}

--- a/crates/wkg/Cargo.toml
+++ b/crates/wkg/Cargo.toml
@@ -23,7 +23,7 @@ oci-wasm = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["ansi"] }
 wasm-pkg-common = { workspace = true }
 wasm-pkg-client = { workspace = true }
 wit-component = { workspace = true }


### PR DESCRIPTION
- **fix(core): use local override over registry dep**
- **test(core): add test for transitive local dep**
- **deps: enable tracing-subscriber ansi feature**

Fixes https://github.com/bytecodealliance/wasm-pkg-tools/issues/132

This PR:
1. Fixes an issue with transitive dependency fetching where a local dependency of a local dependency was treated as a registry dependency, which would fail
1. Adds a test for the above case to ensure that this works
1. Enables the `ansi` feature of tracing-subscriber so we can all have colored logging output <3
