### PR TITLE
fix: RUSTSEC-2024-0402

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -1578,7 +1578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "serde",
 ]
 


### PR DESCRIPTION
Fixes [`RUSTSEC-2024-0402`](https://rustsec.org/advisories/RUSTSEC-2024-0402.html) / [`GHSA-wwq9-3cpr-mm53`](https://github.com/advisories/GHSA-wwq9-3cpr-mm53)