### PR TITLE
Update target for CI with wasm32-wasip1 as wasm32-wasi is removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: "wasm32-wasi"
+          targets: "wasm32-wasip1"
       # We have to run these separately so we can deactivate a feature for one of the tests
       - name: Run client tests
         working-directory: ./crates/wasm-pkg-client


### PR DESCRIPTION
This PR updates the target that CI uses with `wasm32-wasip1`, as `wasm32-wasi` is removed.

Note: This PR is a part of #141, as the CI failure blocks it.