### PR TITLE
Upgrade wasm-tools to 0.224

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: "wasm32-wasi"
+          targets: "wasm32-wasip1"
       # We have to run these separately so we can deactivate a feature for one of the tests
       - name: Run client tests
         working-directory: ./crates/wasm-pkg-client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,6 +1080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1301,9 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
@@ -2194,8 +2203,8 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
- "wit-component",
- "wit-parser",
+ "wit-component 0.219.1",
+ "wit-parser 0.219.1",
 ]
 
 [[package]]
@@ -4323,6 +4332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.224.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
+dependencies = [
+ "leb128",
+ "wasmparser 0.224.0",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.219.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4336,6 +4355,23 @@ dependencies = [
  "spdx",
  "wasm-encoder 0.219.1",
  "wasmparser 0.219.1",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.224.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d13d93febc749413cb6f327e4fdba8c84e4d03bd69fcc4a220c66f113c8de1"
+dependencies = [
+ "anyhow",
+ "indexmap 2.7.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "url",
+ "wasm-encoder 0.224.0",
+ "wasmparser 0.224.0",
 ]
 
 [[package]]
@@ -4367,9 +4403,9 @@ dependencies = [
  "warg-client",
  "warg-crypto",
  "warg-protocol",
- "wasm-metadata",
+ "wasm-metadata 0.224.0",
  "wasm-pkg-common",
- "wit-component",
+ "wit-component 0.224.0",
 ]
 
 [[package]]
@@ -4409,12 +4445,12 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
- "wasm-metadata",
+ "wasm-metadata 0.224.0",
  "wasm-pkg-client",
  "wasm-pkg-common",
  "windows-sys 0.59.0",
- "wit-component",
- "wit-parser",
+ "wit-component 0.224.0",
+ "wit-parser 0.224.0",
 ]
 
 [[package]]
@@ -4461,6 +4497,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
 dependencies = [
  "bitflags 2.6.0",
+ "indexmap 2.7.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.224.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65881a664fdd43646b647bb27bf186ab09c05bf56779d40aed4c6dce47d423f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "hashbrown 0.15.2",
  "indexmap 2.7.0",
  "semver",
 ]
@@ -4767,9 +4815,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.219.1",
- "wasm-metadata",
+ "wasm-metadata 0.219.1",
  "wasmparser 0.219.1",
- "wit-parser",
+ "wit-parser 0.219.1",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.224.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad555ab4f4e676474df746d937823c7279c2d6dd36c3e97a61db893d4ef64ee5"
+dependencies = [
+ "anyhow",
+ "bitflags 2.6.0",
+ "indexmap 2.7.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.224.0",
+ "wasm-metadata 0.224.0",
+ "wasmparser 0.224.0",
+ "wit-parser 0.224.0",
 ]
 
 [[package]]
@@ -4788,6 +4855,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.219.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.224.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e2925a7365d2c6709ae17bdbb5777ffd8154fd70906b413fc01b75f0dba59e"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.7.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.224.0",
 ]
 
 [[package]]
@@ -4810,7 +4895,7 @@ dependencies = [
  "wasm-pkg-client",
  "wasm-pkg-common",
  "wasm-pkg-core",
- "wit-component",
+ "wit-component 0.224.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,6 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
 wasm-pkg-common = { version = "0.9.0", path = "crates/wasm-pkg-common" }
 wasm-pkg-client = { version = "0.9.0", path = "crates/wasm-pkg-client" }
 wasm-pkg-core = { version = "0.9.0", path = "crates/wasm-pkg-core" }
-wasm-metadata = "0.219"
-wit-component = "0.219"
-wit-parser = "0.219"
+wasm-metadata = "0.224"
+wit-component = "0.224"
+wit-parser = "0.224"

--- a/crates/wasm-pkg-core/src/config.rs
+++ b/crates/wasm-pkg-core/src/config.rs
@@ -16,6 +16,7 @@ pub const CONFIG_FILE_NAME: &str = "wkg.toml";
 /// The structure for a wkg.toml configuration file. This file is entirely optional and is used for
 /// overriding and annotating wasm packages.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// Overrides for various packages
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -59,6 +60,7 @@ impl Config {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Override {
     /// A path to the package on disk. If this is set, the package will be loaded from the given
     /// path. If this is not set, the package will be loaded from the registry.
@@ -71,18 +73,19 @@ pub struct Override {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Metadata {
-    /// The authors of the package.
+    /// The author(s) of the package.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,
     /// The package description.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// The package license.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "license")]
     pub licenses: Option<String>,
     /// The package source code URL.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "repository")]
     pub source: Option<String>,
     /// The package homepage URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/wasm-pkg-core/src/config.rs
+++ b/crates/wasm-pkg-core/src/config.rs
@@ -9,7 +9,6 @@ use anyhow::{Context, Result};
 use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
-use wasm_metadata::{Link, LinkType, RegistryMetadata};
 
 /// The default name of the configuration file.
 pub const CONFIG_FILE_NAME: &str = "wkg.toml";
@@ -75,56 +74,22 @@ pub struct Override {
 pub struct Metadata {
     /// The authors of the package.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub authors: Option<Vec<String>>,
-    /// The categories of the package.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub categories: Option<Vec<String>>,
+    pub author: Option<String>,
     /// The package description.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// The package license.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub license: Option<String>,
-    /// The package documentation URL.
+    pub licenses: Option<String>,
+    /// The package source code URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub documentation: Option<String>,
+    pub source: Option<String>,
     /// The package homepage URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub homepage: Option<String>,
-    /// The package repository URL.
+    /// The package source control revision.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<String>,
-}
-
-impl From<Metadata> for wasm_metadata::RegistryMetadata {
-    fn from(value: Metadata) -> Self {
-        let mut meta = RegistryMetadata::default();
-        meta.set_authors(value.authors);
-        meta.set_categories(value.categories);
-        meta.set_description(value.description);
-        meta.set_license(value.license);
-        let mut links = Vec::new();
-        if let Some(documentation) = value.documentation {
-            links.push(Link {
-                ty: LinkType::Documentation,
-                value: documentation,
-            });
-        }
-        if let Some(homepage) = value.homepage {
-            links.push(Link {
-                ty: LinkType::Homepage,
-                value: homepage,
-            });
-        }
-        if let Some(repository) = value.repository {
-            links.push(Link {
-                ty: LinkType::Repository,
-                value: repository,
-            });
-        }
-        meta.set_links((!links.is_empty()).then_some(links));
-        meta
-    }
+    pub revision: Option<String>,
 }
 
 #[cfg(test)]
@@ -144,13 +109,12 @@ mod tests {
                 },
             )])),
             metadata: Some(Metadata {
-                authors: Some(vec!["foo".to_string(), "bar".to_string()]),
-                categories: Some(vec!["foo".to_string(), "bar".to_string()]),
-                description: Some("foo".to_string()),
-                license: Some("foo".to_string()),
-                documentation: Some("foo".to_string()),
-                homepage: Some("foo".to_string()),
-                repository: Some("foo".to_string()),
+                author: Some("Foo Bar".to_string()),
+                description: Some("Foobar baz".to_string()),
+                licenses: Some("FBB".to_string()),
+                source: Some("https://gitfoo/bar".to_string()),
+                homepage: Some("https://foo.bar".to_string()),
+                revision: Some("f00ba4".to_string()),
             }),
         };
 

--- a/crates/wasm-pkg-core/src/lock.rs
+++ b/crates/wasm-pkg-core/src/lock.rs
@@ -606,7 +606,7 @@ mod sys {
     }
 
     pub(super) fn error_contended(err: &Error) -> bool {
-        err.raw_os_error().map_or(false, |x| x == libc::EWOULDBLOCK)
+        err.raw_os_error() == Some(libc::EWOULDBLOCK)
     }
 
     pub(super) fn error_unsupported(err: &Error) -> bool {

--- a/crates/wasm-pkg-core/tests/fixtures/cli-example/.cargo/config.toml
+++ b/crates/wasm-pkg-core/tests/fixtures/cli-example/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = [ "wasm32-wasi" ]
+target = [ "wasm32-wasip1" ]

--- a/crates/wasm-pkg-core/tests/fixtures/dog-fetcher/.cargo/config.toml
+++ b/crates/wasm-pkg-core/tests/fixtures/dog-fetcher/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = [ "wasm32-wasi" ]
+target = [ "wasm32-wasip1" ]

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -354,7 +354,9 @@ impl GetArgs {
             match wit_component::decode_reader(&mut file) {
                 Ok(DecodedWasm::WitPackage(resolve, pkg)) => {
                     tracing::debug!(?pkg, "decoded WIT package");
-                    Some(wit_component::WitPrinter::default().print(&resolve, pkg, &[])?)
+                    let mut printer = wit_component::WitPrinter::default();
+                    printer.print(&resolve, pkg, &[])?;
+                    Some(printer.output.to_string())
                 }
                 Ok(_) => None,
                 Err(err) => {

--- a/crates/wkg/tests/e2e.rs
+++ b/crates/wkg/tests/e2e.rs
@@ -73,12 +73,12 @@ async fn build_and_publish_with_metadata() {
     );
     assert_eq!(
         annotations.get("org.opencontainers.image.licenses"),
-        meta.license.as_ref(),
+        meta.licenses.as_ref(),
         "License should match"
     );
     assert_eq!(
         annotations.get("org.opencontainers.image.source"),
-        meta.repository.as_ref(),
+        meta.source.as_ref(),
         "Source should match"
     );
     assert_eq!(

--- a/crates/wkg/tests/fixtures/wasi-http/wkg.toml
+++ b/crates/wkg/tests/fixtures/wasi-http/wkg.toml
@@ -4,5 +4,5 @@ categories = ["wasm-pkg"]
 description = "WASI HTTP interface"
 license = "Apache-2.0"
 documentation = "https://docs.foobar.baz"
-homepage = "https://foobar.baz"
+homepage = "https://foobar.baz/"
 repository = "https://github.com/bytecodealliance/wasm-pkg-tools"

--- a/crates/wkg/tests/fixtures/wasi-http/wkg.toml
+++ b/crates/wkg/tests/fixtures/wasi-http/wkg.toml
@@ -1,8 +1,7 @@
 [metadata]
-authors = ["WasmPkg <wasm-pkg@bytecodealliance.org>"]
-categories = ["wasm-pkg"]
+author = "WasmPkg <wasm-pkg@bytecodealliance.org>"
 description = "WASI HTTP interface"
 license = "Apache-2.0"
-documentation = "https://docs.foobar.baz"
+source = "https://github.com/bytecodealliance/wasm-pkg-tools"
 homepage = "https://foobar.baz/"
-repository = "https://github.com/bytecodealliance/wasm-pkg-tools"
+revision = "abcd123"


### PR DESCRIPTION
- BREAKING: Integrate upstream metadata overhaul. The set of fields available changed, meaning this may break some existing config files.
- Adapt to changed `WitPrinter` interface
- Update targets to `wasm32-wasip1`