### PR TITLE
Add support for OCI authors annotation

### DIFF
--- a/crates/wasm-pkg-client/src/oci/publisher.rs
+++ b/crates/wasm-pkg-client/src/oci/publisher.rs
@@ -55,6 +55,12 @@ impl PackagePublisher for OciBackend {
                 homepage.to_string(),
             );
         }
+        if let Some(authors) = &meta.author {
+            annotations.insert(
+                "org.opencontainers.image.authors".to_string(),
+                authors.to_string(),
+            );
+        }
 
         let reference: Reference = self.make_reference(package, Some(version));
         let auth = self.auth(&reference, RegistryOperation::Push).await?;


### PR DESCRIPTION
Follow up to #146, this also allows the authors to be read from the wasm binary and written to the OCI package. Thanks!