### PR TITLE
feat: support specifying OCI namespace details on RegistryMetadata

### DIFF
--- a/crates/wasm-pkg-common/Cargo.toml
+++ b/crates/wasm-pkg-common/Cargo.toml
@@ -11,6 +11,8 @@ readme = "../../README.md"
 [features]
 metadata-client = ["dep:reqwest"]
 tokio = ["tokio/io-util"]
+# Extra features to facilitate making working with OCI images easier
+oci_extras = []
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-pkg-common/src/metadata.rs
+++ b/crates/wasm-pkg-common/src/metadata.rs
@@ -26,9 +26,11 @@ pub struct RegistryMetadata {
     /// OCI Registry
     #[serde(skip_serializing)]
     oci_registry: Option<String>,
+
     /// OCI Namespace Prefix
     #[serde(skip_serializing)]
     oci_namespace_prefix: Option<String>,
+
     /// Warg URL
     #[serde(skip_serializing)]
     warg_url: Option<String>,
@@ -108,6 +110,18 @@ impl RegistryMetadata {
             serde_json::from_value(config.unwrap().into())
                 .map_err(|err| Error::InvalidRegistryMetadata(err.into()))?,
         ))
+    }
+
+    /// Set the OCI registry
+    #[cfg(feature = "oci_extras")]
+    pub fn set_oci_registry(&mut self, registry: Option<String>) {
+        self.oci_registry = registry;
+    }
+
+    /// Set the OCI namespace prefix
+    #[cfg(feature = "oci_extras")]
+    pub fn set_oci_namespace_prefix(&mut self, ns_prefix: Option<String>) {
+        self.oci_namespace_prefix = ns_prefix;
     }
 }
 


### PR DESCRIPTION
This commit adds support for specifying OCI namespace details on a `RegistryMetadata` and avoiding introducing the feature as a breaking change by utilizing an opt-in feature.