### PR TITLE
Trim wasm-pkg-common to allow targetting wasm32-wasip1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,24 +10,34 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            additional_test_flags: ""
+            run_lints: true
+            test_wasm_build: true
           - os: windows-latest
-            additional_test_flags: "--no-default-features"
+            docker_tests_flags: "--no-default-features"
           - os: macos-latest
-            additional_test_flags: "--no-default-features"
+            docker_tests_flags: "--no-default-features"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: "wasm32-wasip1"
-      # We have to run these separately so we can deactivate a feature for one of the tests
-      - name: Run client tests
-        working-directory: ./crates/wasm-pkg-client
-        run: cargo test ${{ matrix.additional_test_flags }}
-      - name: Run wkg tests
-        working-directory: ./crates/wkg
-        run: cargo test ${{ matrix.additional_test_flags }}
-      - name: Run other tests
+
+      - name: Run lints
+        if: matrix.run_lints
+        run: |
+          cargo clippy --workspace --no-default-features
+          cargo clippy --workspace --all-features
+
+      - name: Run tests
         run: cargo test --workspace --exclude wasm-pkg-client --exclude wkg
-      - name: Run cargo clippy
-        run: cargo clippy --all --workspace 
+
+      # NOTE: Docker tests are only run on linux because other platforms haven't
+      # always worked consistently.
+      - name: Run wasm-pkg-client tests
+        run: cargo test -p wasm-pkg-client ${{ matrix.docker_tests_flags }}
+      - name: Run wkg tests
+        run: cargo test -p wkg ${{ matrix.docker_tests_flags }}
+
+      - name: Test wasm32-wasip1 build for wasm-pkg-common
+        if: matrix.test_wasm_build
+        run: cargo build -p wasm-pkg-common --target wasm32-wasip1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4426,6 +4426,7 @@ dependencies = [
  "futures-util",
  "oci-client",
  "oci-wasm",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -4456,7 +4457,6 @@ dependencies = [
  "etcetera",
  "futures-util",
  "http",
- "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -4464,7 +4464,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "toml",
- "tracing",
 ]
 
 [[package]]

--- a/crates/wasm-pkg-client/Cargo.toml
+++ b/crates/wasm-pkg-client/Cargo.toml
@@ -9,9 +9,9 @@ license.workspace = true
 readme = "../../README.md"
 
 [features]
-default = ["_local"]
-# An internal feature for making sure e2e tests can run locally but not in CI for Mac or Windows
-_local = []
+default = ["docker-tests"]
+# This feature enables tests that use Docker
+docker-tests = []
 
 [dependencies]
 anyhow = { workspace = true }
@@ -23,6 +23,13 @@ etcetera = { workspace = true }
 futures-util = { workspace = true, features = ["io"] }
 oci-client = { workspace = true }
 oci-wasm = { workspace = true }
+reqwest = { version = "0.12.0", default-features = false, features = [
+    "charset",
+    "http2",
+    "json",
+    "macos-system-configuration",
+    "rustls-tls",
+]}
 secrecy = { version = "0.8", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -38,7 +45,7 @@ warg-client = "0.9.2"
 warg-crypto = "0.9.2"
 wasm-metadata = { workspace = true }
 warg-protocol = "0.9.2"
-wasm-pkg-common = { workspace = true, features = ["metadata-client", "tokio"] }
+wasm-pkg-common = { workspace = true, features = ["registry-config"] }
 wit-component = { workspace = true }
 
 [dev-dependencies]

--- a/crates/wasm-pkg-client/src/lib.rs
+++ b/crates/wasm-pkg-client/src/lib.rs
@@ -29,6 +29,7 @@
 pub mod caching;
 mod loader;
 pub mod local;
+pub mod metadata;
 pub mod oci;
 mod publisher;
 mod release;
@@ -55,6 +56,7 @@ pub use wasm_pkg_common::{
 };
 use wit_component::DecodedWasm;
 
+use crate::metadata::RegistryMetadataExt;
 use crate::{loader::PackageLoader, local::LocalBackend, oci::OciBackend, warg::WargBackend};
 
 pub use release::{Release, VersionInfo};

--- a/crates/wasm-pkg-client/src/metadata.rs
+++ b/crates/wasm-pkg-client/src/metadata.rs
@@ -1,0 +1,62 @@
+use anyhow::Context;
+use reqwest::StatusCode;
+use wasm_pkg_common::{
+    metadata::{RegistryMetadata, REGISTRY_METADATA_PATH},
+    registry::Registry,
+    Error,
+};
+
+/// Extension trait for [`RegistryMetadata`] adding client functionality.
+pub trait RegistryMetadataExt: Sized {
+    /// Attempt to fetch [`RegistryMetadata`] from the given [`Registry`]. On
+    /// failure, return defaults.
+    fn fetch_or_default(registry: &Registry) -> impl std::future::Future<Output = Self> + Send;
+
+    /// Fetch [`RegistryMetadata`] from the given [`Registry`].
+    fn fetch(
+        registry: &Registry,
+    ) -> impl std::future::Future<Output = Result<Option<Self>, Error>> + Send;
+}
+
+impl RegistryMetadataExt for RegistryMetadata {
+    async fn fetch_or_default(registry: &Registry) -> Self {
+        match Self::fetch(registry).await {
+            Ok(Some(meta)) => {
+                tracing::debug!(?meta, "Got registry metadata");
+                meta
+            }
+            Ok(None) => {
+                tracing::debug!("Metadata not found");
+                Default::default()
+            }
+            Err(err) => {
+                tracing::warn!(error = ?err, "Error fetching registry metadata");
+                Default::default()
+            }
+        }
+    }
+
+    async fn fetch(registry: &Registry) -> Result<Option<Self>, Error> {
+        let scheme = if registry.host() == "localhost" {
+            "http"
+        } else {
+            "https"
+        };
+        let url = format!("{scheme}://{registry}{REGISTRY_METADATA_PATH}");
+        fetch_url(&url)
+            .await
+            .with_context(|| format!("error fetching registry metadata from {url:?}"))
+            .map_err(Error::RegistryMetadataError)
+    }
+}
+
+async fn fetch_url(url: &str) -> anyhow::Result<Option<RegistryMetadata>> {
+    tracing::debug!(?url, "Fetching registry metadata");
+
+    let resp = reqwest::get(url).await?;
+    if resp.status() == StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    let resp = resp.error_for_status()?;
+    Ok(Some(resp.json().await?))
+}

--- a/crates/wasm-pkg-client/tests/e2e.rs
+++ b/crates/wasm-pkg-client/tests/e2e.rs
@@ -1,19 +1,17 @@
 use futures_util::TryStreamExt;
-use testcontainers::{
-    core::{IntoContainerPort, WaitFor},
-    runners::AsyncRunner,
-    GenericImage, ImageExt,
-};
 use wasm_pkg_client::{Client, Config};
 
 const FIXTURE_WASM: &str = "./tests/testdata/binary_wit.wasm";
 
-#[cfg(any(target_os = "linux", feature = "_local"))]
-// NOTE: These are only run on linux for CI purposes, because they rely on the docker client being
-// available, and for various reasons this has proven to be problematic on both the Windows and
-// MacOS runners due to it not being installed (yay licensing).
+#[cfg(feature = "docker-tests")]
 #[tokio::test]
 async fn publish_and_fetch_smoke_test() {
+    use testcontainers::{
+        core::{IntoContainerPort, WaitFor},
+        runners::AsyncRunner,
+        GenericImage, ImageExt,
+    };
+
     let _container = GenericImage::new("registry", "2")
         .with_wait_for(WaitFor::message_on_stderr("listening on [::]:5000"))
         .with_mapped_port(5001, 5000.tcp())

--- a/crates/wasm-pkg-common/Cargo.toml
+++ b/crates/wasm-pkg-common/Cargo.toml
@@ -9,32 +9,27 @@ license.workspace = true
 readme = "../../README.md"
 
 [features]
-metadata-client = ["dep:reqwest"]
-tokio = ["tokio/io-util"]
+registry-config = [
+    "dep:etcetera",
+    "dep:tokio",
+    "dep:toml",
+]
 # Extra features to facilitate making working with OCI images easier
 oci_extras = []
 
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }
-etcetera = { workspace = true }
+etcetera = { workspace = true, optional = true }
 futures-util = { workspace = true }
 http = "1.1.0"
-reqwest = { version = "0.12.0", default-features = false, features = [
-    "rustls-tls",
-    "charset",
-    "http2",
-    "macos-system-configuration",
-    "json",
-], optional = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
-toml = { workspace = true }
+tokio = { workspace = true, optional = true, features = ["fs"] }
+toml = { workspace = true, optional = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/wasm-pkg-common/src/digest.rs
+++ b/crates/wasm-pkg-common/src/digest.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "tokio")]
-use std::path::Path;
 use std::str::FromStr;
 
 use bytes::Bytes;
@@ -16,22 +14,6 @@ pub enum ContentDigest {
 }
 
 impl ContentDigest {
-    #[cfg(feature = "tokio")]
-    pub async fn sha256_from_file(path: impl AsRef<Path>) -> Result<Self, std::io::Error> {
-        use tokio::io::AsyncReadExt;
-        let mut file = tokio::fs::File::open(path).await?;
-        let mut hasher = Sha256::new();
-        let mut buf = [0; 4096];
-        loop {
-            let n = file.read(&mut buf).await?;
-            if n == 0 {
-                break;
-            }
-            hasher.update(&buf[..n]);
-        }
-        Ok(hasher.into())
-    }
-
     pub fn validating_stream(
         &self,
         stream: impl TryStream<Ok = Bytes, Error = Error>,

--- a/crates/wasm-pkg-common/src/lib.rs
+++ b/crates/wasm-pkg-common/src/lib.rs
@@ -1,6 +1,7 @@
 use http::uri::InvalidUri;
 use label::Label;
 
+#[cfg(feature = "registry-config")]
 pub mod config;
 pub mod digest;
 pub mod label;
@@ -50,10 +51,4 @@ pub enum Error {
     RegistryMetadataError(#[source] anyhow::Error),
     #[error("version not found: {0}")]
     VersionNotFound(semver::Version),
-}
-
-impl Error {
-    fn invalid_config(err: impl Into<anyhow::Error>) -> Self {
-        Self::InvalidConfig(err.into())
-    }
 }

--- a/crates/wkg/Cargo.toml
+++ b/crates/wkg/Cargo.toml
@@ -9,9 +9,9 @@ license.workspace = true
 readme = "../../README.md"
 
 [features]
-default = ["_local"]
-# An internal feature for making sure e2e tests can run locally but not in CI for Mac or Windows
-_local = []
+default = ["docker-tests"]
+# This feature enables tests that use Docker
+docker-tests = []
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wkg/src/oci.rs
+++ b/crates/wkg/src/oci.rs
@@ -171,7 +171,7 @@ impl PushArgs {
 
 fn digest_from_manifest_url(url: &str) -> &str {
     url.split('/')
-        .last()
+        .next_back()
         .expect("url did not contain manifest sha256")
 }
 

--- a/crates/wkg/tests/e2e.rs
+++ b/crates/wkg/tests/e2e.rs
@@ -1,9 +1,6 @@
 mod common;
 
-#[cfg(any(target_os = "linux", feature = "_local"))]
-// NOTE: These are only run on linux for CI purposes, because they rely on the docker client being
-// available, and for various reasons this has proven to be problematic on both the Windows and
-// MacOS runners due to it not being installed (yay licensing).
+#[cfg(feature = "docker-tests")]
 #[tokio::test]
 async fn build_and_publish_with_metadata() {
     use oci_client::{client::ClientConfig, manifest::OciManifest, Reference};


### PR DESCRIPTION
A fair bit of collateral damage on this one:

- Moved or made optional some `wasm-pkg-common` deps that don't build on wasm32-wasip1:
  - Replaced the `wasm-pkg-common` `tokio` feature flag with a broader `registry-config` flag which allows disabling more deps (notably `etcetera`)
  - Moved some functionality from `wasm-pkg-common` to `wasm-pkg-client` (the only place they were being used afaict): `ContentDigest::sha256_from_file`, `RegistryMetadata::fetch*`
- Cleaned up CI while adding wasm32-wasip1 build check
  - Reorganized steps to check cheaper things earlier
  - Renamed `_local` feature flag to more descriptive `docker-tests`
- Appease clippy

Fixes #162