### PR TITLE
Reduce level of invalid semver OCI tag to WARN

### DIFF
--- a/crates/wasm-pkg-client/src/oci/loader.rs
+++ b/crates/wasm-pkg-client/src/oci/loader.rs
@@ -36,7 +36,7 @@ impl PackageLoader for OciBackend {
                     yanked: false,
                 }),
                 Err(err) => {
-                    tracing::warn!(?tag, error = ?err, "Ignoring invalid version tag");
+                    tracing::debug!(?tag, error = ?err, "Ignoring invalid version tag");
                     None
                 }
             })


### PR DESCRIPTION
WASI packages are publishing cosign signatures with the same prefix as WIT packages: https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp

Pragmatically this turns this warning into unhelpful noise, so we'll drop the level to debug.