### PR TITLE
Build binary to be compatible with downlevel Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: "ubuntu-22.04"
             run_lints: true
             test_wasm_build: true
           - os: windows-latest


### PR DESCRIPTION
Fixes #158.

Building on `ubuntu-latest` results in the binary being dependent on the latest version(s) of glibc.  When a user running Ubuntu 22 (me. it's me) runs the `wkg` binary, it fails with `wkg: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by wkg)`.

By building on `ubuntu-22.04`, we maximise compatibility across Ubuntu versions.

