### PR TITLE
Use registry host rather than URL for creds lookup

### DIFF
--- a/crates/wasm-pkg-client/src/oci/mod.rs
+++ b/crates/wasm-pkg-client/src/oci/mod.rs
@@ -112,31 +112,17 @@ impl OciBackend {
             ));
         }
 
-        match docker_credential::get_credential(&self.oci_registry) {
-            Ok(DockerCredential::UsernamePassword(username, password)) => {
-                return Ok(RegistryAuth::Basic(username, password));
-            }
-            Ok(DockerCredential::IdentityToken(_)) => {
-                return Err(Error::CredentialError(anyhow::anyhow!(
-                    "identity tokens not supported"
-                )));
-            }
-            Err(err) => {
-                if matches!(
-                    err,
-                    CredentialRetrievalError::ConfigNotFound
-                        | CredentialRetrievalError::ConfigReadError
-                        | CredentialRetrievalError::NoCredentialConfigured
-                        | CredentialRetrievalError::HelperFailure { .. }
-                ) {
-                    tracing::debug!("Failed to look up OCI credentials: {err}");
-                } else {
-                    tracing::warn!("Failed to look up OCI credentials: {err}");
-                };
+        match get_docker_credential(&self.oci_registry)? {
+            Some(c) => Ok(c),
+            None => {
+                tracing::debug!("Failed to look up OCI credentials by registry, trying server URL");
+                let server_url = format!("https://{}", self.oci_registry);
+                match get_docker_credential(&server_url)? {
+                    Some(c) => Ok(c),
+                    None => Ok(RegistryAuth::Anonymous),
+                }
             }
         }
-
-        Ok(RegistryAuth::Anonymous)
     }
 
     pub(crate) fn make_reference(
@@ -163,4 +149,32 @@ pub(crate) fn oci_registry_error(err: OciDistributionError) -> Error {
         OciDistributionError::ImageManifestNotFoundError(_) => Error::PackageNotFound,
         _ => Error::RegistryError(err.into()),
     }
+}
+
+fn get_docker_credential(registry: &str) -> Result<Option<RegistryAuth>, Error> {
+    match docker_credential::get_credential(registry) {
+        Ok(DockerCredential::UsernamePassword(username, password)) => {
+            return Ok(Some(RegistryAuth::Basic(username, password)));
+        }
+        Ok(DockerCredential::IdentityToken(_)) => {
+            return Err(Error::CredentialError(anyhow::anyhow!(
+                "identity tokens not supported"
+            )));
+        }
+        Err(err) => {
+            if matches!(
+                err,
+                CredentialRetrievalError::ConfigNotFound
+                    | CredentialRetrievalError::ConfigReadError
+                    | CredentialRetrievalError::NoCredentialConfigured
+                    | CredentialRetrievalError::HelperFailure { .. }
+            ) {
+                tracing::debug!("Failed to look up OCI credentials: {err}");
+            } else {
+                tracing::warn!("Failed to look up OCI credentials: {err}");
+            };
+        }
+    }
+
+    Ok(None)
 }


### PR DESCRIPTION
There is an issue in GitHub actions where `wkg publish` fails with code `DENIED` even after a successful `docker login`.

The reason appears to be that `wkg` asks `docker-credential` to look up credentials for the schemeful `server_url` (e.g. `https://ghcr.io`), whereas `~/.docker/config.json` contains bare hosts (e.g. `ghcr.io`).  `docker-credential` does not normalise away the schema of the passed-in lookup key, so never matches the schemeful entry.

This PR proposes changing the lookup to use the `oci_registry` of the backend type, rather than the URL.

This also fixes an issue on WSL, where the `docker-credential-desktop.exe` store also requires matching the bare host.

That said, I don't know what _else_ is relying on having the full URL.  The current code has been there for nearly 18 months and I'm assuming it was done that way for a reason.  So if we want to be more conservative, we can try a more complicated solution where we test with the `oci_registry` first, and if that fails, try with the constructed `server_url`.  I'll let wiser heads decide whether that's worth it!
