### PR TITLE
ci: add riscv64gc-unknown-linux-gnu to release binaries

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -33,6 +33,9 @@ jobs:
           - rust-target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             cross: true
+          - rust-target: riscv64gc-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
           - rust-target: x86_64-apple-darwin
             os: macos-latest
           - rust-target: aarch64-apple-darwin
@@ -87,6 +90,9 @@ jobs:
           - rust-target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - rust-target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - rust-target: riscv64gc-unknown-linux-gnu
             os: ubuntu-latest
             cross: true
           - rust-target: x86_64-apple-darwin

--- a/Cross.toml
+++ b/Cross.toml
@@ -9,3 +9,15 @@ env.passthrough = [
     "OPENSSL_STATIC=yes"
 ]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
+
+[target.riscv64gc-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH",
+]
+env.passthrough = [
+    "OPENSSL_LIB_DIR=/usr/lib/riscv64-linux-gnu",
+    "OPENSSL_INCLUDE_DIR=/usr/include/riscv64-linux-gnu/openssl",
+    "OPENSSL_STATIC=yes"
+]
+image = "ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:edge"


### PR DESCRIPTION
## Summary

- Add `riscv64gc-unknown-linux-gnu` to both `publish_dev_release` and `publish_tagged_release` build matrices, using `cross` for cross-compilation (same approach as the existing `aarch64-unknown-linux-gnu` target)
- Add corresponding `Cross.toml` entry with OpenSSL cross-compilation configuration for riscv64

## Motivation

Fixes https://github.com/bytecodealliance/wasm-pkg-tools/issues/195

RISC-V adoption is growing and `wkg` builds successfully for `riscv64gc-unknown-linux-gnu`. Adding this target to the release workflow means users on RISC-V Linux can download pre-built binaries instead of building from source.

## Evidence

Successfully built and published `wkg` for riscv64 on a fork release: https://github.com/gounthar/wasm-pkg-tools/releases/tag/v0.15.0

## Changes

- `.github/workflows/publish-binaries.yml`: Added `riscv64gc-unknown-linux-gnu` matrix entry (with `cross: true`) to both dev and tagged release jobs
- `Cross.toml`: Added `[target.riscv64gc-unknown-linux-gnu]` section with OpenSSL dependencies and the `edge` cross-rs image

## Test plan

- [ ] CI matrix expands to include the new riscv64 target
- [ ] `cross build --release --target riscv64gc-unknown-linux-gnu` succeeds
- [ ] Release artifacts include `wkg-riscv64gc-unknown-linux-gnu`