### PR TITLE
ci: add riscv64gc-unknown-linux-gnu to release binaries

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -33,6 +33,9 @@ jobs:
           - rust-target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             cross: true
+          - rust-target: riscv64gc-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
           - rust-target: x86_64-apple-darwin
             os: macos-latest
           - rust-target: aarch64-apple-darwin
@@ -87,6 +90,9 @@ jobs:
           - rust-target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - rust-target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - rust-target: riscv64gc-unknown-linux-gnu
             os: ubuntu-latest
             cross: true
           - rust-target: x86_64-apple-darwin

--- a/Cross.toml
+++ b/Cross.toml
@@ -9,3 +9,15 @@ env.passthrough = [
     "OPENSSL_STATIC=yes"
 ]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
+
+[target.riscv64gc-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH",
+]
+env.passthrough = [
+    "OPENSSL_LIB_DIR=/usr/lib/riscv64-linux-gnu",
+    "OPENSSL_INCLUDE_DIR=/usr/include/riscv64-linux-gnu/openssl",
+    "OPENSSL_STATIC=yes"
+]
+image = "ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:edge"


### PR DESCRIPTION
This adds `riscv64gc-unknown-linux-gnu` to both the dev and tagged release build matrices, so that official releases ship a pre-built Linux/RISC-V 64-bit binary (`wkg-riscv64gc-unknown-linux-gnu`).

## Changes

- **`.github/workflows/publish-binaries.yml`** : new matrix entry in both  `publish_dev_release` and `publish_tagged_release` jobs, using `cross: true`
- **`Cross.toml`**: new `[target.riscv64gc-unknown-linux-gnu]` section with OpenSSL cross-compilation configuration (mirroring the existing aarch64 entry)

## Evidence

A fork release built with `cross` targeting riscv64gc is available at https://github.com/gounthar/wasm-pkg-tools/releases/tag/v0.15.0 : the `wkg-riscv64gc-unknown-linux-gnu` binary was verified on physical RISC-V hardware (BananaPi BPI-F3, SpacemiT K1, Armbian Linux trixie).

Fixes https://github.com/bytecodealliance/wasm-pkg-tools/issues/195