### PR TITLE
fix(resolver,config): remove references to root package in override dependencies

### DIFF
--- a/crates/wasm-pkg-client/src/oci/mod.rs
+++ b/crates/wasm-pkg-client/src/oci/mod.rs
@@ -101,6 +101,13 @@ impl OciBackend {
                 Ok(auth)
             })
             .await
+            .map_err(|e| {
+                if let Error::RegistryError(anyhow_err) = e {
+                    Error::RegistryError(anyhow_err.context(reference.repository().to_owned()))
+                } else {
+                    e
+                }
+            })
             .cloned()
     }
 

--- a/crates/wasm-pkg-core/src/resolver.rs
+++ b/crates/wasm-pkg-core/src/resolver.rs
@@ -730,6 +730,11 @@ impl DependencyResolutionMap {
                     package,
                 } => {
                     source_files.extend(package.source_map.source_files().map(Path::to_path_buf));
+                    // handle cases for a workspace level `wkg.toml` where overrides may reference
+                    // the package being built
+                    if package.main.name == root.main.name {
+                        continue;
+                    }
                     merged.push_group(package).with_context(|| {
                         format!(
                             "failed to merge dependency `{name}`",


### PR DESCRIPTION
Currently having a "workspace" level `wkg.toml` is not possible since for any package being built, they will also show up as a dependency in the config:

```toml
# wkg.toml
[overrides]
"namespace:foo" = { path = "./foo" }
"namespace:bar" = { path = "./bar" }
```

```sh-session
$ wkg wit build --wit-dir ./foo/

Error: failed to merge package from directory `.`

Caused by:
    attempting to re-add package `namespace:foo@7.2.0` when it's already present in this `Resolve`
```