### PR TITLE
improve error message when wasm binary is missing package version

### DIFF
--- a/crates/wasm-pkg-client/src/lib.rs
+++ b/crates/wasm-pkg-client/src/lib.rs
@@ -338,7 +338,18 @@ fn resolve_package(
         })?;
 
     let version = version.ok_or_else(|| {
-        crate::Error::InvalidComponent(anyhow::anyhow!("component package version not found"))
+        crate::Error::InvalidComponent(anyhow::anyhow!(
+            "component package version not found in the Wasm binary\n\
+            \n\
+            The Wasm file was built without a version in the WIT `package` statement.\n\
+            Add a version to the `package` statement in your .wit file, e.g.:\n\
+            \n\
+            \tpackage example:my-package@1.0.0;\n\
+            \n\
+            Alternatively, specify the package and version explicitly with the --package flag:\n\
+            \n\
+            \twkg publish <file> --package <namespace>:<name>@<version>"
+        ))
     })?;
     Ok((data.into_inner(), package, version))
 }


### PR DESCRIPTION
Fixes #117.

When `wkg publish` encounters a Wasm binary that has no version in the embedded package metadata (because the WIT `package` statement was written without a `@version`), the previous error message was:

```
Error: malformed component: component package version not found
```

This gives no indication of what went wrong or how to fix it. The improved message explains the cause and offers two remediation paths:

```
Error: malformed component: component package version not found in the Wasm binary

The Wasm file was built without a version in the WIT `package` statement.
Add a version to the `package` statement in your .wit file, e.g.:

    package example:my-package@1.0.0;

Alternatively, specify the package and version explicitly with the --package flag:

    wkg publish <file> --package <namespace>:<name>@<version>
```