### PR TITLE
fix: assume the 127.0.0.1 being insecure registry host that uses http…

### DIFF
--- a/crates/wasm-pkg-client/src/metadata.rs
+++ b/crates/wasm-pkg-client/src/metadata.rs
@@ -37,7 +37,7 @@ impl RegistryMetadataExt for RegistryMetadata {
     }
 
     async fn fetch(registry: &Registry) -> Result<Option<Self>, Error> {
-        let scheme = if registry.host() == "localhost" {
+        let scheme = if registry.host() == "localhost" || registry.host() == "127.0.0.1" {
             "http"
         } else {
             "https"


### PR DESCRIPTION
Well, in warg and other's check for 127.0.0.1, i assume that's the intended behavior.

However, the insecure registries can be marked with the --insecure param in cli, which then configures oci client to use them, but the registry metadata is fetched with raw http request, so maybe it shold be 1:1, pass through the insecure map to the point of fetching?