### PR TITLE
fix: clear error when wkg get output directory does not exist

### DIFF
--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -322,6 +322,13 @@ impl GetArgs {
                 .context("Failed to resolve output parent dir")?
         };
 
+        if !parent_dir.exists() {
+            anyhow::bail!(
+                "output directory {:?} does not exist; create it first or choose a different path",
+                parent_dir
+            );
+        }
+
         let (tmp_file, tmp_path) =
             tempfile::NamedTempFile::with_prefix_in(".wkg-get", parent_dir)?.into_parts();
         tracing::debug!(?tmp_path, "Created temporary file");


### PR DESCRIPTION
Fixes #118.

When `wkg get -o some_dir/` is used and `some_dir` doesn't exist, the previous error was:

```
Error: No such file or directory (os error 2) at path "/path/to/some_dir/.wkg-getT7LRZK"
```

The temp file name in the path sends the user in the wrong direction. The fix checks that `parent_dir` exists before attempting to create the temp file, and reports a clear error:

```
Error: output directory "/path/to/some_dir/" does not exist; create it first or choose a different path
```