### PR TITLE
wasm-pkg-client: support extra_root_certificates and accept_invalid_certificates when fetching/publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "astral-tokio-tar"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +455,15 @@ name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -935,6 +983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1026,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2500,6 +2568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "olpc-cjson"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +2747,16 @@ dependencies = [
  "prost 0.12.6",
  "prost-build",
  "serde",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -3182,6 +3269,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,6 +3540,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -4990,6 +5100,7 @@ dependencies = [
  "futures-util",
  "oci-client",
  "oci-wasm",
+ "rcgen",
  "reqwest 0.12.28",
  "secrecy",
  "serde",
@@ -5641,6 +5752,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static 1.5.0",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5669,6 +5798,16 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ oci-client = { version = "0.16", default-features = false, features = [
 oci-wasm = { version = "0.4", default-features = false, features = [
     "rustls-tls",
 ] }
+rcgen = "0.14.8"
 semver = "1.0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/crates/wasm-pkg-client/Cargo.toml
+++ b/crates/wasm-pkg-client/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { version = "0.12.0", default-features = false, features = [
     "json",
     "macos-system-configuration",
     "rustls-tls",
-]}
+] }
 secrecy = { version = "0.8", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -49,5 +49,6 @@ wasm-pkg-common = { workspace = true, features = ["registry-config"] }
 wit-component = { workspace = true }
 
 [dev-dependencies]
+rcgen = { workspace = true }
 tempfile = { workspace = true }
 testcontainers = { workspace = true }

--- a/crates/wasm-pkg-client/src/oci/config.rs
+++ b/crates/wasm-pkg-client/src/oci/config.rs
@@ -3,7 +3,7 @@ use base64::{
     engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
     Engine,
 };
-use oci_client::client::ClientConfig;
+use oci_client::client::{Certificate, CertificateEncoding, ClientConfig};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize, Serializer};
 use wasm_pkg_common::{config::RegistryConfig, Error};
@@ -50,8 +50,12 @@ impl TryFrom<&RegistryConfig> for OciRegistryConfig {
     type Error = Error;
 
     fn try_from(registry_config: &RegistryConfig) -> Result<Self, Self::Error> {
-        let OciRegistryConfigToml { auth, protocol } =
-            registry_config.backend_config("oci")?.unwrap_or_default();
+        let OciRegistryConfigToml {
+            auth,
+            protocol,
+            accept_invalid_certificates,
+            extra_root_certificates,
+        } = registry_config.backend_config("oci")?.unwrap_or_default();
         let mut client_config = ClientConfig::default();
         if let Some(protocol) = protocol {
             client_config.protocol = oci_client_protocol(&protocol)?;
@@ -59,6 +63,12 @@ impl TryFrom<&RegistryConfig> for OciRegistryConfig {
         let credentials = auth
             .map(TryInto::try_into)
             .transpose()
+            .map_err(Error::InvalidConfig)?;
+        client_config.accept_invalid_certificates = accept_invalid_certificates;
+        client_config.extra_root_certificates = extra_root_certificates
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>, _>>()
             .map_err(Error::InvalidConfig)?;
         Ok(Self {
             client_config,
@@ -71,16 +81,31 @@ impl TryFrom<&RegistryConfig> for OciRegistryConfig {
 struct OciRegistryConfigToml {
     auth: Option<TomlAuth>,
     protocol: Option<String>,
+    #[serde(default)]
+    accept_invalid_certificates: bool,
+    #[serde(default)]
+    extra_root_certificates: Vec<TomlCertificate>,
 }
 
 impl From<OciRegistryConfig> for OciRegistryConfigToml {
     fn from(value: OciRegistryConfig) -> Self {
+        let OciRegistryConfig {
+            client_config,
+            credentials,
+        } = value;
+
         OciRegistryConfigToml {
-            auth: value.credentials.map(|c| TomlAuth::UsernamePassword {
+            auth: credentials.map(|c| TomlAuth::UsernamePassword {
                 username: c.username,
                 password: c.password,
             }),
-            protocol: Some(oci_protocol_string(&value.client_config.protocol)),
+            protocol: Some(oci_protocol_string(&client_config.protocol)),
+            accept_invalid_certificates: client_config.accept_invalid_certificates,
+            extra_root_certificates: client_config
+                .extra_root_certificates
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 }
@@ -161,6 +186,47 @@ fn serialize_secret<S: Serializer>(
     secret.expose_secret().serialize(serializer)
 }
 
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum TomlCertificateEncoding {
+    Der,
+    Pem,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct TomlCertificate {
+    encoding: TomlCertificateEncoding,
+    data: String,
+}
+
+impl TryFrom<TomlCertificate> for Certificate {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TomlCertificate) -> Result<Self, Self::Error> {
+        let (encoding, data) = match value.encoding {
+            TomlCertificateEncoding::Der => (CertificateEncoding::Der, value.data.into_bytes()),
+            TomlCertificateEncoding::Pem => (CertificateEncoding::Pem, value.data.into_bytes()),
+        };
+        Ok(Self { encoding, data })
+    }
+}
+
+impl From<Certificate> for TomlCertificate {
+    fn from(value: Certificate) -> Self {
+        let (encoding, data) = match value.encoding {
+            CertificateEncoding::Der => (
+                TomlCertificateEncoding::Der,
+                String::from_utf8_lossy(&value.data).into_owned(),
+            ),
+            CertificateEncoding::Pem => (
+                TomlCertificateEncoding::Pem,
+                String::from_utf8_lossy(&value.data).into_owned(),
+            ),
+        };
+        Self { encoding, data }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use wasm_pkg_common::config::RegistryMapping;
@@ -197,6 +263,8 @@ mod tests {
             oci_client::client::ClientProtocol::Http,
             oci_config.client_config.protocol
         );
+        assert!(!oci_config.client_config.accept_invalid_certificates);
+        assert!(oci_config.client_config.extra_root_certificates.is_empty());
 
         let oci_config: OciRegistryConfig = cfg
             .registry_config(&"wasi.dev".parse().unwrap())

--- a/crates/wasm-pkg-client/tests/e2e.rs
+++ b/crates/wasm-pkg-client/tests/e2e.rs
@@ -58,6 +58,78 @@ async fn publish_and_fetch_smoke_test() {
     assert_eq!(content, expected_content);
 }
 
+#[cfg(feature = "docker-tests")]
+#[tokio::test]
+async fn publish_and_fetch_succeed_with_self_signed_registry() {
+    use testcontainers::{
+        core::{IntoContainerPort, WaitFor},
+        runners::AsyncRunner,
+        GenericImage, ImageExt,
+    };
+
+    let (fixture_pem_cert, fixture_pem_key) = generate_self_signed_tls_fixture();
+
+    let test_cases = [
+        (
+            "extra_root_certificates",
+            format!(
+                r#"
+        extra_root_certificates = [
+            {{ encoding = "pem", data = """{fixture_pem_cert}""" }}
+        ]
+    "#
+            ),
+        ),
+        (
+            "accept_invalid_certificates",
+            "accept_invalid_certificates = true".to_string(),
+        ),
+    ];
+
+    for (case_name, case_config) in test_cases {
+        let container = GenericImage::new("registry", "2")
+            .with_wait_for(WaitFor::message_on_stderr("listening on"))
+            .with_exposed_port(5000.tcp())
+            .with_copy_to("/certs/domain.crt", fixture_pem_cert.as_bytes().to_vec())
+            .with_copy_to("/certs/domain.key", fixture_pem_key.as_bytes().to_vec())
+            .with_env_var("REGISTRY_HTTP_ADDR", "0.0.0.0:5000")
+            .with_env_var("REGISTRY_HTTP_TLS_CERTIFICATE", "/certs/domain.crt")
+            .with_env_var("REGISTRY_HTTP_TLS_KEY", "/certs/domain.key")
+            .start()
+            .await
+            .expect("Failed to start TLS registry test container");
+
+        let port = container.get_host_port_ipv4(5000.tcp()).await.unwrap();
+
+        let config = Config::from_toml(&format!(
+            r#"
+        default_registry = "localhost:{port}"
+
+        [registry."localhost:{port}"]
+        type = "oci"
+        [registry."localhost:{port}".oci]
+        protocol = "https"
+        {case_config}
+    "#
+        ))
+        .unwrap();
+        let client = Client::new(config);
+
+        let (package, _version) = client
+            .publish_release_file(FIXTURE_WASM, Default::default())
+            .await
+            .unwrap_or_else(|e| panic!("[{case_name}] publish should succeed:\n{e:#}"));
+
+        let release = client
+            .get_release(&package, &"0.2.0".parse().unwrap())
+            .await
+            .unwrap_or_else(|e| panic!("[{case_name}] get_release should succeed:\n{e:#}"));
+        if let Err(err) = client.stream_content(&package, &release).await {
+            panic!("[{case_name}] fetch should succeed over self-signed TLS:\n{err:#}");
+        }
+    }
+}
+
 // Simple smoke test to make sure the custom metadata section is parsed and used correctly. Down the
 // line we might want to just push a thing to a local registry and then fetch it, but for now we'll
 // just use the bytecodealliance registry.
@@ -81,4 +153,12 @@ async fn fetch_with_custom_config() {
         !versions.is_empty(),
         "Should be able to list versions with custom config"
     );
+}
+
+fn generate_self_signed_tls_fixture() -> (String, String) {
+    let subject_alt_names = vec!["localhost".to_string(), "127.0.0.1".to_string()];
+    let rcgen::CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(subject_alt_names)
+            .expect("Failed to generate self-signed TLS certificate");
+    (cert.pem(), signing_key.serialize_pem())
 }


### PR DESCRIPTION
closes #127 

Lifts ClientConfig fields `accept_invalid_certificates` and `extra_root_certificates` into the OciRegistryConfig such that it can be passed through ClientConfig and ultimately to the reqwest client. 