### PR TITLE
feat(publish): allow directory path for `wkg publish`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -652,9 +652,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2297,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "logos"
@@ -3921,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3941,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5891,9 +5891,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -566,8 +566,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic",
  "tonic-prost",
  "ureq",
@@ -583,7 +583,7 @@ dependencies = [
  "bollard-buildkit-proto",
  "bytes",
  "chrono",
- "prost 0.14.3",
+ "prost 0.14.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -613,9 +613,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cbc"
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1050,7 +1050,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1545,24 +1544,21 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1587,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1697,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2147,13 +2143,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2230,9 +2225,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -2357,9 +2352,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -2997,28 +2992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,12 +3012,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -3083,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3118,11 +3091,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -3368,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3391,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -4080,9 +4053,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -4180,9 +4153,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4237,7 +4210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4333,12 +4306,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4348,15 +4320,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4574,7 +4546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -5006,27 +4978,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5037,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5047,9 +5010,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5057,9 +5020,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5070,9 +5033,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -5120,12 +5083,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.251.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -5278,9 +5241,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags",
  "indexmap 2.14.0",
@@ -5299,31 +5262,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "251.0.0"
+version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7467dda0a96142eb2c980329dfb62480b1e1d3622fdeb1a44e2bca6ceed74"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.251.0",
+ "wasm-encoder 0.252.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.251.0"
+version = "1.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b1086c9e85b95bd6a229a928bc6c6d0662e42af0250c88d067b418831ea4d4"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5341,18 +5304,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5709,60 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
 
 [[package]]
 name = "wit-component"
@@ -5976,18 +5888,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6017,18 +5929,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/wasm-pkg-client/src/local.rs
+++ b/crates/wasm-pkg-client/src/local.rs
@@ -71,7 +71,6 @@ impl PackageLoader for LocalBackend {
         let mut entries = tokio::fs::read_dir(&package_dir)
             .await
             .map_err(|e| registry_path_context(e, &package_dir))?;
-        tracing::debug!("READ IT");
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
             if path.extension() != Some("wasm".as_ref()) {
@@ -141,6 +140,7 @@ impl PackagePublisher for LocalBackend {
         let mut out = tokio::fs::File::create(&path)
             .await
             .map_err(|e| registry_path_context(e, &path))?;
+        println!("writing to {}", path.display());
         tokio::io::copy(&mut data, &mut out)
             .await
             .map_err(Error::IoError)

--- a/crates/wasm-pkg-client/src/local.rs
+++ b/crates/wasm-pkg-client/src/local.rs
@@ -2,7 +2,10 @@
 //!
 //! Each package release is a file: `<root>/<namespace>/<name>/<version>.wasm`
 
-use std::path::{Path, PathBuf};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -33,6 +36,11 @@ pub(crate) struct LocalBackend {
     root: PathBuf,
 }
 
+fn registry_path_context(err: io::Error, path: &Path) -> Error {
+    let err = anyhow::Error::new(err).context(format!("path: {}", path.display()));
+    Error::RegistryError(err)
+}
+
 impl LocalBackend {
     pub fn new(registry_config: RegistryConfig) -> Result<Self, Error> {
         let config = registry_config
@@ -60,7 +68,10 @@ impl PackageLoader for LocalBackend {
         let mut versions = vec![];
         let package_dir = self.package_dir(package);
         tracing::debug!(?package_dir, "Reading versions from path");
-        let mut entries = tokio::fs::read_dir(package_dir).await?;
+        let mut entries = tokio::fs::read_dir(&package_dir)
+            .await
+            .map_err(|e| registry_path_context(e, &package_dir))?;
+        tracing::debug!("READ IT");
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
             if path.extension() != Some("wasm".as_ref()) {
@@ -86,7 +97,9 @@ impl PackageLoader for LocalBackend {
     async fn get_release(&self, package: &PackageRef, version: &Version) -> Result<Release, Error> {
         let path = self.version_path(package, version);
         tracing::debug!(path = %path.display(), "Reading content from path");
-        let content_digest = sha256_from_file(path).await?;
+        let content_digest = sha256_from_file(&path)
+            .await
+            .map_err(|e| registry_path_context(e, &path))?;
         Ok(Release {
             version: version.clone(),
             content_digest,
@@ -100,7 +113,9 @@ impl PackageLoader for LocalBackend {
     ) -> Result<ContentStream, Error> {
         let path = self.version_path(package, &content.version);
         tracing::debug!("Streaming content from {path:?}");
-        let file = tokio::fs::File::open(path).await?;
+        let file = tokio::fs::File::open(&path)
+            .await
+            .map_err(|e| registry_path_context(e, &path))?;
         Ok(ReaderStream::new(file).map_err(Into::into).boxed())
     }
 }
@@ -116,12 +131,16 @@ impl PackagePublisher for LocalBackend {
     ) -> Result<(), Error> {
         let package_dir = self.package_dir(package);
         // Ensure the package directory exists.
-        tokio::fs::create_dir_all(package_dir).await?;
+        tokio::fs::create_dir_all(&package_dir)
+            .await
+            .map_err(|e| registry_path_context(e, &package_dir))?;
         let path = self.version_path(package, version);
         if dry_run {
             return Ok(());
         }
-        let mut out = tokio::fs::File::create(path).await?;
+        let mut out = tokio::fs::File::create(&path)
+            .await
+            .map_err(|e| registry_path_context(e, &path))?;
         tokio::io::copy(&mut data, &mut out)
             .await
             .map_err(Error::IoError)

--- a/crates/wasm-pkg-client/src/local.rs
+++ b/crates/wasm-pkg-client/src/local.rs
@@ -140,7 +140,7 @@ impl PackagePublisher for LocalBackend {
         let mut out = tokio::fs::File::create(&path)
             .await
             .map_err(|e| registry_path_context(e, &path))?;
-        println!("writing to {}", path.display());
+        tracing::info!("publishing to {}", path.display());
         tokio::io::copy(&mut data, &mut out)
             .await
             .map_err(Error::IoError)

--- a/crates/wasm-pkg-common/src/config.rs
+++ b/crates/wasm-pkg-common/src/config.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use ::toml::Value;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -134,16 +135,6 @@ impl Config {
         etcetera::choose_base_strategy()
             .ok()
             .map(|strat| strat.config_dir().join("wasm-pkg").join("config.toml"))
-    }
-
-    // take relative paths (such as those provided by [`LocalConfig`]'s `root` field) and make them
-    // absolute
-    fn normalize_paths(mut self, config_file: &Path) -> Result<Self, Error> {
-        for (_, registry_config) in self.registry_configs.iter_mut() {
-            if let Some(local_config) = registry_config.backend_config::<LocalConfig>("local")? {}
-
-            if let Some(path) = backend_configs.get_mut("local").map(|v| v.get_mut("root")) {}
-        }
     }
 
     /// Reads config from a TOML file at the given path.

--- a/crates/wasm-pkg-common/src/config.rs
+++ b/crates/wasm-pkg-common/src/config.rs
@@ -4,7 +4,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ::toml::Value;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/crates/wasm-pkg-common/src/config.rs
+++ b/crates/wasm-pkg-common/src/config.rs
@@ -136,6 +136,16 @@ impl Config {
             .map(|strat| strat.config_dir().join("wasm-pkg").join("config.toml"))
     }
 
+    // take relative paths (such as those provided by [`LocalConfig`]'s `root` field) and make them
+    // absolute
+    fn normalize_paths(mut self, config_file: &Path) -> Result<Self, Error> {
+        for (_, registry_config) in self.registry_configs.iter_mut() {
+            if let Some(local_config) = registry_config.backend_config::<LocalConfig>("local")? {}
+
+            if let Some(path) = backend_configs.get_mut("local").map(|v| v.get_mut("root")) {}
+        }
+    }
+
     /// Reads config from a TOML file at the given path.
     pub async fn from_file(path: impl AsRef<Path>) -> Result<Self, Error> {
         let contents = tokio::fs::read_to_string(path)

--- a/crates/wasm-pkg-common/src/lib.rs
+++ b/crates/wasm-pkg-common/src/lib.rs
@@ -45,7 +45,7 @@ pub enum Error {
     NoRegistryForNamespace(Label),
     #[error("Package not found")]
     PackageNotFound,
-    #[error("registry error: {0}")]
+    #[error("registry error")]
     RegistryError(#[source] anyhow::Error),
     #[error("registry metadata error: {0:#}")]
     RegistryMetadataError(#[source] anyhow::Error),

--- a/crates/wasm-pkg-common/src/lib.rs
+++ b/crates/wasm-pkg-common/src/lib.rs
@@ -45,7 +45,7 @@ pub enum Error {
     NoRegistryForNamespace(Label),
     #[error("Package not found")]
     PackageNotFound,
-    #[error("registry error")]
+    #[error("registry error: {0:#}")]
     RegistryError(#[source] anyhow::Error),
     #[error("registry metadata error: {0:#}")]
     RegistryMetadataError(#[source] anyhow::Error),

--- a/crates/wasm-pkg-core/src/lock.rs
+++ b/crates/wasm-pkg-core/src/lock.rs
@@ -48,6 +48,9 @@ impl PartialEq for LockFile {
         self.packages == other.packages && self.version == other.version
     }
 }
+/// Compares a [`LockFile`] against a `(version, packages)` snapshot. This is used to
+/// detect whether a build would mutate the lock file (e.g. before publishing) without
+/// having to hold a second [`LockFile`].
 impl PartialEq<(u64, BTreeSet<LockedPackage>)> for LockFile {
     fn eq(&self, other: &(u64, BTreeSet<LockedPackage>)) -> bool {
         self.packages == other.1 && self.version == other.0

--- a/crates/wasm-pkg-core/src/lock.rs
+++ b/crates/wasm-pkg-core/src/lock.rs
@@ -48,6 +48,11 @@ impl PartialEq for LockFile {
         self.packages == other.packages && self.version == other.version
     }
 }
+impl PartialEq<(u64, BTreeSet<LockedPackage>)> for LockFile {
+    fn eq(&self, other: &(u64, BTreeSet<LockedPackage>)) -> bool {
+        self.packages == other.1 && self.version == other.0
+    }
+}
 
 impl Eq for LockFile {}
 

--- a/crates/wasm-pkg-core/src/resolver.rs
+++ b/crates/wasm-pkg-core/src/resolver.rs
@@ -556,10 +556,18 @@ impl<'a> DependencyResolver<'a> {
                         // the version requirement; this can happen when packages are yanked. If we did
                         // find an exact match, return the digest for comparison after fetching the
                         // release
-                        find_latest_release(versions, &exact_req).map(|v| (&v.version, Some(digest))).or_else(|| find_latest_release(versions, &dependency.version).map(|v| (&v.version, None)))
-                    }
+                        find_latest_release(versions, &exact_req)
+                            .map(|v| (&v.version, Some(digest)))
+                            .or_else(|| find_latest_release(versions, &dependency.version).map(|v| (&v.version, None)))
+                        }
                     None => find_latest_release(versions, &dependency.version).map(|v| (&v.version, None)),
-                }.with_context(|| format!("component registry package `{name}` has no release matching version requirement `{version}`", name = dependency.package, version = dependency.version))?
+                }.with_context(||
+                    format!(
+                        "component registry package `{name}` has no release matching version requirement `{version}`",
+                        name = dependency.package,
+                        version = dependency.version
+                    )
+                )?
             };
 
             // We need to clone a handle to the client because we mutably borrow self above. Might

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -273,11 +273,16 @@ impl PublishArgs {
                 wit::build_wit_dir(&self.path, client.clone(), &mut lock_file).await?;
             // There is no way to check if we are in a git repository unlike `cargo publish --allow-dirty` so
             // check against previous values.
-            if lock_file != prev_lock_ref {
+            if lock_file != prev_lock_ref && !self.dry_run {
                 return Err(anyhow::anyhow!(
                     "wkg.lock would be updated during publish, aborting"
                 ))
-                .context("Run `wkg wit fetch` before attempting to publish");
+                .with_context(|| {
+                    format!(
+                        "Run `wkg wit build {}` before attempting to publish",
+                        self.path.to_string_lossy()
+                    )
+                });
             }
 
             let tmp = tempfile::Builder::new()

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -266,10 +266,7 @@ impl PublishArgs {
         // If the input is a directory, build a WIT package from it into a temp
         // file first. _tmp is held until the publish completes so the file
         // isn't deleted out from under us.
-        let metadata = tokio::fs::metadata(&self.path)
-            .await
-            .with_context(|| format!("Failed to stat {:?}", self.path))?;
-        let (publish_path, _tmp) = if metadata.is_dir() {
+        let (publish_path, _tmp) = if self.path.is_dir() {
             let mut lock_file = LockFile::load(false).await?;
             let prev_lock_ref = (lock_file.version, lock_file.packages.clone());
             let (build_ref, _, bytes) =

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -290,7 +290,10 @@ impl PublishArgs {
             tokio::fs::write(tmp.path(), &bytes)
                 .await
                 .context("Failed to write built WIT package to temp file")?;
-            (tmp.path().to_path_buf(), Some(tmp))
+            let tmp_pkg_path = tmp.path().to_path_buf();
+            tracing::debug!(tmp_pkg_path = %tmp_pkg_path.display(), "Wrote temporary WIT package file");
+
+            (tmp_pkg_path, Some(tmp))
         } else {
             (self.path.clone(), None)
         };

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -15,6 +15,7 @@ use wasm_pkg_common::{
     package::PackageSpec,
     registry::Registry,
 };
+use wasm_pkg_core::lock::LockFile;
 use wit_component::DecodedWasm;
 
 mod oci;
@@ -227,8 +228,9 @@ struct GetArgs {
 
 #[derive(Args, Debug)]
 struct PublishArgs {
-    /// The file to publish
-    file: PathBuf,
+    /// The file or directory to publish.
+    /// If a directory is provided, the package is built to a tempfile before publishing.
+    path: PathBuf,
 
     #[command(flatten)]
     registry_args: RegistryArgs,
@@ -260,10 +262,43 @@ impl PublishArgs {
         } else {
             None
         };
+
+        // If the input is a directory, build a WIT package from it into a temp
+        // file first. _tmp is held until the publish completes so the file
+        // isn't deleted out from under us.
+        let metadata = tokio::fs::metadata(&self.path)
+            .await
+            .with_context(|| format!("Failed to stat {:?}", self.path))?;
+        let (publish_path, _tmp) = if metadata.is_dir() {
+            let mut lock_file = LockFile::load(false).await?;
+            let prev_lock_ref = (lock_file.version, lock_file.packages.clone());
+            let (build_ref, _, bytes) =
+                wit::build_wit_dir(&self.path, client.clone(), &mut lock_file).await?;
+            let tmp = tempfile::Builder::new()
+                .prefix(&build_ref.to_string())
+                .suffix(".wasm")
+                .tempfile()
+                .context("Failed to create temporary file for built WIT package")?;
+            // There is no way to check if we are in a git repository unlike `cargo publish --allow-dirty` so
+            // check against previous values.
+            if lock_file != prev_lock_ref {
+                return Err(anyhow::anyhow!(
+                    "wkg.lock would be updated during publish, aborting"
+                ))
+                .context("Run `wkg wit fetch` before attempting to publish");
+            }
+            tokio::fs::write(tmp.path(), &bytes)
+                .await
+                .context("Failed to write built WIT package to temp file")?;
+            (tmp.path().to_path_buf(), Some(tmp))
+        } else {
+            (self.path.clone(), None)
+        };
+
         let (package, version) = client
             .client()?
             .publish_release_file(
-                &self.file,
+                &publish_path,
                 PublishOpts {
                     package,
                     registry: self.registry_args.registry,

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -267,7 +267,7 @@ impl PublishArgs {
         // file first. _tmp is held until the publish completes so the file
         // isn't deleted out from under us.
         let (publish_path, _tmp) = if self.path.is_dir() {
-            let mut lock_file = LockFile::load(false).await?;
+            let mut lock_file = LockFile::load(true).await?;
             let prev_lock_ref = (lock_file.version, lock_file.packages.clone());
             let (build_ref, _, bytes) =
                 wit::build_wit_dir(&self.path, client.clone(), &mut lock_file).await?;

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -271,11 +271,6 @@ impl PublishArgs {
             let prev_lock_ref = (lock_file.version, lock_file.packages.clone());
             let (build_ref, _, bytes) =
                 wit::build_wit_dir(&self.path, client.clone(), &mut lock_file).await?;
-            let tmp = tempfile::Builder::new()
-                .prefix(&build_ref.to_string())
-                .suffix(".wasm")
-                .tempfile()
-                .context("Failed to create temporary file for built WIT package")?;
             // There is no way to check if we are in a git repository unlike `cargo publish --allow-dirty` so
             // check against previous values.
             if lock_file != prev_lock_ref {
@@ -284,6 +279,12 @@ impl PublishArgs {
                 ))
                 .context("Run `wkg wit fetch` before attempting to publish");
             }
+
+            let tmp = tempfile::Builder::new()
+                .prefix(&build_ref.to_string())
+                .suffix(".wasm")
+                .tempfile()
+                .context("Failed to create temporary file for built WIT package")?;
             tokio::fs::write(tmp.path(), &bytes)
                 .await
                 .context("Failed to write built WIT package to temp file")?;

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -285,8 +285,12 @@ impl PublishArgs {
                 });
             }
 
+            // Sanitize the package ref for use as a filename prefix: `namespace:name`
+            // contains characters (`:`, `/`) that are invalid in filenames on some
+            // platforms (notably Windows).
+            let prefix: String = build_ref.to_string().replace([':', '/'], "_");
             let tmp = tempfile::Builder::new()
-                .prefix(&build_ref.to_string())
+                .prefix(&prefix)
                 .suffix(".wasm")
                 .tempfile()
                 .context("Failed to create temporary file for built WIT package")?;

--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -24,6 +24,8 @@ mod wit;
 use oci::OciCommands;
 use wit::WitCommands;
 
+use crate::wit::temp_wit_file;
+
 #[derive(Parser, Debug)]
 #[command(version)]
 struct Cli {
@@ -252,15 +254,15 @@ impl PublishArgs {
     pub async fn run(self) -> anyhow::Result<()> {
         let client = self.common.get_client().await?;
 
-        let package = if let Some(package) = self.package {
-            Some((
-                package.package,
-                package.version.ok_or_else(|| {
-                    anyhow::anyhow!("version is required when manually overriding the package ID")
-                })?,
-            ))
-        } else {
-            None
+        let package = match self.package {
+            Some(PackageSpec {
+                package,
+                version: Some(v),
+            }) => Some((package, v)),
+            Some(PackageSpec { version: None, .. }) => {
+                anyhow::bail!("version is required when manually overriding the package ID");
+            }
+            None => None,
         };
 
         // If the input is a directory, build a WIT package from it into a temp
@@ -269,7 +271,7 @@ impl PublishArgs {
         let (publish_path, _tmp) = if self.path.is_dir() {
             let mut lock_file = LockFile::load(true).await?;
             let prev_lock_ref = (lock_file.version, lock_file.packages.clone());
-            let (build_ref, _, bytes) =
+            let (pkg_ref, _, bytes) =
                 wit::build_wit_dir(&self.path, client.clone(), &mut lock_file).await?;
             // There is no way to check if we are in a git repository unlike `cargo publish --allow-dirty` so
             // check against previous values.
@@ -285,22 +287,9 @@ impl PublishArgs {
                 });
             }
 
-            // Sanitize the package ref for use as a filename prefix: `namespace:name`
-            // contains characters (`:`, `/`) that are invalid in filenames on some
-            // platforms (notably Windows).
-            let prefix: String = build_ref.to_string().replace([':', '/'], "_");
-            let tmp = tempfile::Builder::new()
-                .prefix(&prefix)
-                .suffix(".wasm")
-                .tempfile()
-                .context("Failed to create temporary file for built WIT package")?;
-            tokio::fs::write(tmp.path(), &bytes)
-                .await
-                .context("Failed to write built WIT package to temp file")?;
-            let tmp_pkg_path = tmp.path().to_path_buf();
-            tracing::debug!(tmp_pkg_path = %tmp_pkg_path.display(), "Wrote temporary WIT package file");
+            let tmp = temp_wit_file(&pkg_ref, &bytes).await?;
 
-            (tmp_pkg_path, Some(tmp))
+            (tmp.path().to_path_buf(), Some(tmp))
         } else {
             (self.path.clone(), None)
         };

--- a/crates/wkg/src/wit.rs
+++ b/crates/wkg/src/wit.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::{Args, Subcommand};
+use tempfile::NamedTempFile;
 use wasm_pkg_client::caching::{CachingClient, FileCache};
 use wasm_pkg_common::package::{PackageRef, Version};
 use wasm_pkg_core::{
@@ -121,6 +122,26 @@ pub async fn build_wit_dir(
     let wkg_config = wasm_pkg_core::config::Config::load().await?;
     let result = wit::build_package(&wkg_config, dir, lock_file, client).await?;
     Ok(result)
+}
+
+pub async fn temp_wit_file(package: &PackageRef, bytes: &[u8]) -> anyhow::Result<NamedTempFile> {
+    // Sanitize the package ref for use as a filename prefix: `namespace:name`
+    // contains characters (`:`, `/`) that are invalid in filenames on some
+    // platforms (notably Windows).
+    let prefix: String = package.to_string().replace([':', '/'], "_");
+    let tmp_handle = tempfile::Builder::new()
+        .prefix(&prefix)
+        .suffix(".wasm")
+        .tempfile()
+        .context("Failed to create temporary file for built WIT package")
+        .with_context(|| format!("package: {package}"))?;
+    tokio::fs::write(tmp_handle.path(), &bytes)
+        .await
+        .context("Failed to write built WIT package to temp file")
+        .with_context(|| format!("package: {package}"))?;
+
+    tracing::debug!(tmp_pkg_path = %tmp_handle.path().display(), "Wrote temporary WIT package file");
+    Ok(tmp_handle)
 }
 
 impl FetchArgs {

--- a/crates/wkg/src/wit.rs
+++ b/crates/wkg/src/wit.rs
@@ -119,7 +119,7 @@ pub async fn build_wit_dir(
 ) -> anyhow::Result<(PackageRef, Option<Version>, Vec<u8>)> {
     check_dir(&dir).await?;
     let wkg_config = wasm_pkg_core::config::Config::load().await?;
-    let result = wit::build_package(&wkg_config, dir, &mut lock_file, client).await?;
+    let result = wit::build_package(&wkg_config, dir, lock_file, client).await?;
     Ok(result)
 }
 

--- a/crates/wkg/src/wit.rs
+++ b/crates/wkg/src/wit.rs
@@ -115,7 +115,7 @@ impl BuildArgs {
 pub async fn build_wit_dir(
     dir: impl AsRef<Path>,
     client: CachingClient<FileCache>,
-    mut lock_file: &mut LockFile,
+    lock_file: &mut LockFile,
 ) -> anyhow::Result<(PackageRef, Option<Version>, Vec<u8>)> {
     check_dir(&dir).await?;
     let wkg_config = wasm_pkg_core::config::Config::load().await?;

--- a/crates/wkg/src/wit.rs
+++ b/crates/wkg/src/wit.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::{Args, Subcommand};
+use wasm_pkg_client::caching::{CachingClient, FileCache};
+use wasm_pkg_common::package::{PackageRef, Version};
 use wasm_pkg_core::{
     lock::LockFile,
     wit::{self, OutputType},
@@ -86,12 +88,9 @@ pub struct UpdateArgs {
 
 impl BuildArgs {
     pub async fn run(self) -> anyhow::Result<()> {
-        check_dir(&self.dir).await?;
         let client = self.common.get_client().await?;
-        let wkg_config = wasm_pkg_core::config::Config::load().await?;
         let mut lock_file = LockFile::load(false).await?;
-        let (pkg_ref, version, bytes) =
-            wit::build_package(&wkg_config, self.dir, &mut lock_file, client).await?;
+        let (pkg_ref, version, bytes) = build_wit_dir(&self.dir, client, &mut lock_file).await?;
         let output_path = if let Some(path) = self.output {
             path
         } else {
@@ -109,6 +108,19 @@ impl BuildArgs {
         println!("WIT package written to {}", output_path.display());
         Ok(())
     }
+}
+
+/// Build a WIT package from a directory, returning the resolved package ref, optional
+/// version, and the encoded component bytes.
+pub async fn build_wit_dir(
+    dir: impl AsRef<Path>,
+    client: CachingClient<FileCache>,
+    mut lock_file: &mut LockFile,
+) -> anyhow::Result<(PackageRef, Option<Version>, Vec<u8>)> {
+    check_dir(&dir).await?;
+    let wkg_config = wasm_pkg_core::config::Config::load().await?;
+    let result = wit::build_package(&wkg_config, dir, &mut lock_file, client).await?;
+    Ok(result)
 }
 
 impl FetchArgs {
@@ -154,5 +166,9 @@ impl UpdateArgs {
 }
 
 async fn check_dir(dir: impl AsRef<Path>) -> anyhow::Result<()> {
-    tokio::fs::metadata(dir).await.context("Unable to read wit directory. This command should be run from the parent directory of the wit directory or a directory can be overridden with the --wit-dir argument").map(|_|())
+    let dir = dir.as_ref();
+    tokio::fs::metadata(dir).await
+        .with_context(|| format!("unable to read wit directory: {}", dir.display()))
+        .context("This command should be run from the parent directory of the wit directory or a directory can be overridden with the --wit-dir argument")
+        .map(|_|())
 }


### PR DESCRIPTION
Moved parts of `wkg wit build` into shared function to allow logic reuse between publish and build:
https://github.com/bytecodealliance/wasm-pkg-tools/blob/a84022459b8c3e71f4d8d1304eca71a7c3d55277/crates/wkg/src/wit.rs#L113-L124

`wkg publish ./wit/` will abort if it would result in changing `wkg.lock`