### PR TITLE
refactor!(core,cli): rename `wasm_pkg_core::config::Config` to `wasm_pkg_core::config::Manifest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ example = "example.com"
 # (see the section on "metadata" below). But many times you might want to override mappings or
 # provide something that is used by a single team. The registry name does not matter, but must be
 # parsable to URL authority. This name is purely used for mapping to registry config and isn't
-# actually used as a URL when metadata is provided 
+# actually used as a URL when metadata is provided
 another = { registry = "another", metadata = { preferredProtocol = "oci", "oci" = {registry = "ghcr.io", namespacePrefix = "webassembly/" } } }
 
-# This overrides the default registry for a specific package. This is useful for cases where a 
-# package is published to multiple registries. 
+# This overrides the default registry for a specific package. This is useful for cases where a
+# package is published to multiple registries.
 [package_registry_overrides]
 "example:foo" = "example.com"
 # Same as namespace_registries above, but for a specific package.
@@ -103,7 +103,7 @@ another = { registry = "another", metadata = { preferredProtocol = "oci", "oci" 
 # to use by default. If this is not set, then the fallback (oci) will be used.
 default = "warg"
 [registry."acme.registry.com".warg]
-# A path to a valid warg config file. If this is not set, the `wkg` CLI (but not the libraries) 
+# A path to a valid warg config file. If this is not set, the `wkg` CLI (but not the libraries)
 # will attempt to load the config from the default location(s).
 config_file = "/a/path"
 # An optional authentication token to use when authenticating with a registry.
@@ -113,7 +113,7 @@ auth_token = "an-auth-token"
 # hatch for when you need to use a key that isn't in the keychain.
 signing_key = "ecdsa-p256:2CV1EpLaSYEn4In4OAEDAj5O4Hzu8AFAxgHXuG310Ew="
 [registry."acme.registry.com".oci]
-# The auth field can either be a username/password pair, or a base64 encoded `username:password` 
+# The auth field can either be a username/password pair, or a base64 encoded `username:password`
 # string. If no auth is set, the `wkg` CLI (but not the libraries) will also attempt to load the
 # credentials from the docker config.json. This field is also optional and if not set, anonymous
 # auth will be used. If you're just pulling from a public registry, this is likely not required.
@@ -167,7 +167,7 @@ A full example of what this `registry.json` file should look like is below:
 
 The `preferredProtocol` field is optional and specifies which protocol the registry expects you to
 use in the case where it supports both OCI and Warg. If both `warg` and `oci` config is in the
-`registry.json` it is _highly recommended_ that this field be set. 
+`registry.json` it is _highly recommended_ that this field be set.
 
 For the `oci` config, the `registry` field is the base URL of the OCI registry, and the
 `namespacePrefix` field is the prefix that is used to store components in the registry. So in the
@@ -215,7 +215,7 @@ the tooling will ignore it when pulling.
 ### Default fallback registries
 
 If no configuration is found, the following mapping of namespace prefixes is used as a fallback:
-```
+```toml
 wasi = "wasi.dev"
 ba = "bytecodealliance.org"
 ```
@@ -274,7 +274,7 @@ version = "0.2.0"
 digest = "sha256:5d535edc544d06719cf337861b7917c3d565360295e5dc424046dceddb0a0e42"
 ```
 
-On the other hand, the `wkg.toml` file is used to configure various parts of the tooling and _is
+On the other hand, the `wkg.toml` manifest file is used to configure various parts of the tooling and _is
 entirely optional_. Projects are not required to use this file. Currently, it serves two purposes:
 adding additional metadata and overriding versions/dependencies. The most common usage will be to
 point to a local dependency:

--- a/crates/wasm-pkg-core/src/config.rs
+++ b/crates/wasm-pkg-core/src/config.rs
@@ -17,7 +17,7 @@ pub const CONFIG_FILE_NAME: &str = "wkg.toml";
 /// overriding and annotating wasm packages.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct Config {
+pub struct Manifest {
     /// Overrides for various packages
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub overrides: Option<HashMap<String, Override>>,
@@ -27,14 +27,14 @@ pub struct Config {
     pub metadata: Option<Metadata>,
 }
 
-impl Config {
+impl Manifest {
     /// Loads a configuration file from the given path.
-    pub async fn load_from_path(path: impl AsRef<Path>) -> Result<Config> {
+    pub async fn load_from_path(path: impl AsRef<Path>) -> Result<Manifest> {
         tracing::info!(path = %path.as_ref().display(), "loading wkg config file");
         let contents = tokio::fs::read_to_string(path)
             .await
             .context("unable to load config from file")?;
-        let config: Config = toml::from_str(&contents).context("unable to parse config file")?;
+        let config: Manifest = toml::from_str(&contents).context("unable to parse config file")?;
         Ok(config)
     }
 
@@ -42,10 +42,10 @@ impl Config {
     /// crate should use this function. Right now it just checks for a `wkg.toml` file in the current
     /// directory, but we could add more resolution logic in the future. If the file is not found, a
     /// default empty config is returned.
-    pub async fn load() -> Result<Config> {
+    pub async fn load() -> Result<Manifest> {
         let config_path = PathBuf::from(CONFIG_FILE_NAME);
         if !tokio::fs::try_exists(&config_path).await? {
-            return Ok(Config::default());
+            return Ok(Manifest::default());
         }
         Self::load_from_path(config_path).await
     }
@@ -115,7 +115,7 @@ mod tests {
     async fn test_roundtrip() {
         let tempdir = tempfile::tempdir().unwrap();
         let config_path = tempdir.path().join(CONFIG_FILE_NAME);
-        let config = Config {
+        let config = Manifest {
             overrides: Some(HashMap::from([(
                 "foo:bar".to_string(),
                 Override {
@@ -137,7 +137,7 @@ mod tests {
             .write(&config_path)
             .await
             .expect("unable to write config");
-        let loaded_config = Config::load_from_path(config_path)
+        let loaded_config = Manifest::load_from_path(config_path)
             .await
             .expect("unable to load config");
         assert_eq!(

--- a/crates/wasm-pkg-core/src/lib.rs
+++ b/crates/wasm-pkg-core/src/lib.rs
@@ -2,7 +2,7 @@
 //! other downstream CLI tools that may need to leverage some of the same functionality provided by
 //! `wkg`.
 
-pub mod config;
 pub mod lock;
+pub mod manifest;
 pub mod resolver;
 pub mod wit;

--- a/crates/wasm-pkg-core/src/manifest.rs
+++ b/crates/wasm-pkg-core/src/manifest.rs
@@ -10,10 +10,10 @@ use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 
-/// The default name of the configuration file.
-pub const CONFIG_FILE_NAME: &str = "wkg.toml";
+/// The default name of the manifest file.
+pub const MANIFEST_FILE_NAME: &str = "wkg.toml";
 
-/// The structure for a wkg.toml configuration file. This file is entirely optional and is used for
+/// The structure for a wkg.toml manifest file. This file is entirely optional and is used for
 /// overriding and annotating wasm packages.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -28,35 +28,36 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    /// Loads a configuration file from the given path.
+    /// Loads a manifest file from the given path.
     pub async fn load_from_path(path: impl AsRef<Path>) -> Result<Manifest> {
-        tracing::info!(path = %path.as_ref().display(), "loading wkg config file");
+        tracing::info!(path = %path.as_ref().display(), "loading wkg manifest file");
         let contents = tokio::fs::read_to_string(path)
             .await
-            .context("unable to load config from file")?;
-        let config: Manifest = toml::from_str(&contents).context("unable to parse config file")?;
-        Ok(config)
+            .context("unable to load manifest from file")?;
+        let manifest: Manifest =
+            toml::from_str(&contents).context("unable to parse manifest file")?;
+        Ok(manifest)
     }
 
-    /// Attempts to load the configuration from the current directory. Most of the time, users of this
+    /// Attempts to load the manifest from the current directory. Most of the time, users of this
     /// crate should use this function. Right now it just checks for a `wkg.toml` file in the current
     /// directory, but we could add more resolution logic in the future. If the file is not found, a
-    /// default empty config is returned.
+    /// default empty manifest is returned.
     pub async fn load() -> Result<Manifest> {
-        let config_path = PathBuf::from(CONFIG_FILE_NAME);
-        if !tokio::fs::try_exists(&config_path).await? {
+        let manifest_path = PathBuf::from(MANIFEST_FILE_NAME);
+        if !tokio::fs::try_exists(&manifest_path).await? {
             return Ok(Manifest::default());
         }
-        Self::load_from_path(config_path).await
+        Self::load_from_path(manifest_path).await
     }
 
-    /// Serializes and writes the configuration to the given path.
+    /// Serializes and writes the manifest to the given path.
     pub async fn write(&self, path: impl AsRef<Path>) -> Result<()> {
         let contents = toml::to_string_pretty(self)?;
         let mut file = tokio::fs::File::create(path).await?;
         file.write_all(contents.as_bytes())
             .await
-            .context("unable to write config to path")
+            .context("unable to write manifest to path")
     }
 
     /// Returns a matching override name and value for the input path
@@ -114,8 +115,8 @@ mod tests {
     #[tokio::test]
     async fn test_roundtrip() {
         let tempdir = tempfile::tempdir().unwrap();
-        let config_path = tempdir.path().join(CONFIG_FILE_NAME);
-        let config = Manifest {
+        let manifest_path = tempdir.path().join(MANIFEST_FILE_NAME);
+        let manifest = Manifest {
             overrides: Some(HashMap::from([(
                 "foo:bar".to_string(),
                 Override {
@@ -133,16 +134,16 @@ mod tests {
             }),
         };
 
-        config
-            .write(&config_path)
+        manifest
+            .write(&manifest_path)
             .await
-            .expect("unable to write config");
-        let loaded_config = Manifest::load_from_path(config_path)
+            .expect("unable to write manifest");
+        let loaded_manifest = Manifest::load_from_path(manifest_path)
             .await
-            .expect("unable to load config");
+            .expect("unable to load manifest");
         assert_eq!(
-            config, loaded_config,
-            "config loaded from file does not match original config"
+            manifest, loaded_manifest,
+            "manifest loaded from file does not match original manifest"
         );
     }
 }

--- a/crates/wasm-pkg-core/src/resolver.rs
+++ b/crates/wasm-pkg-core/src/resolver.rs
@@ -345,7 +345,7 @@ pub struct DependencyResolver<'a> {
 }
 
 impl<'a> DependencyResolver<'a> {
-    /// Creates a new dependency resolver. If `config` is `None`, then the resolver will be set to
+    /// Creates a new dependency resolver. If [`Config`] is `None`, then the resolver will be set to
     /// offline mode and a lock file must be given as well. Anything that will require network
     /// access will fail in offline mode.
     pub fn new(

--- a/crates/wasm-pkg-core/src/wit.rs
+++ b/crates/wasm-pkg-core/src/wit.rs
@@ -19,8 +19,8 @@ use wit_component::WitPrinter;
 use wit_parser::{PackageId, PackageName, Resolve};
 
 use crate::{
-    config::Manifest,
     lock::LockFile,
+    manifest::Manifest,
     resolver::{
         DecodedDependency, Dependency, DependencyGraph, DependencyResolution,
         DependencyResolutionMap, DependencyResolver, LocalPackageIndex, LocalResolution,
@@ -51,15 +51,15 @@ impl FromStr for OutputType {
     }
 }
 
-/// Builds a WIT package given the configuration and directory to parse. Will update the given lock
+/// Builds a WIT package given the manifest and directory to parse. Will update the given lock
 /// file with the resolved dependencies but will not write it to disk.
 pub async fn build_package(
-    config: &Manifest,
+    manifest: &Manifest,
     wit_dir: impl AsRef<Path>,
     lock_file: &mut LockFile,
     client: CachingClient<FileCache>,
 ) -> Result<(PackageRef, Option<Version>, Vec<u8>)> {
-    let dependencies = resolve_dependencies(config, &wit_dir, Some(lock_file), client)
+    let dependencies = resolve_dependencies(manifest, &wit_dir, Some(lock_file), client)
         .await
         .context("Unable to resolve dependencies")?;
 
@@ -69,7 +69,7 @@ pub async fn build_package(
         .generate_resolve(wit_dir.as_ref())
         .await
         .map_err(|e| {
-            if config.has_override(wit_dir.as_ref()) {
+            if manifest.has_override(wit_dir.as_ref()) {
                 e.context("hint: override present for WIT directory".to_string())
             } else {
                 e
@@ -98,7 +98,7 @@ pub async fn build_package(
 
     let processed_by_version = option_env!("WIT_VERSION_INFO").unwrap_or(env!("CARGO_PKG_VERSION"));
 
-    let metadata = config.metadata.clone().unwrap_or_default();
+    let metadata = manifest.metadata.clone().unwrap_or_default();
     let add_metadata = {
         /// MetadataField::Set iff the given Option is Some
         fn set<T: std::fmt::Debug + Clone>(opt: Option<T>) -> AddMetadataField<T> {
@@ -130,14 +130,14 @@ pub async fn build_package(
 ///
 /// This is mostly a convenience wrapper around [`resolve_dependencies`] and [`populate_dependencies`].
 pub async fn fetch_dependencies(
-    config: &Manifest,
+    manifest: &Manifest,
     wit_dir: impl AsRef<Path>,
     lock_file: &mut LockFile,
     client: CachingClient<FileCache>,
     output: OutputType,
 ) -> Result<()> {
     // Don't pass lock file if update is true
-    let dependencies = resolve_dependencies(config, &wit_dir, Some(lock_file), client).await?;
+    let dependencies = resolve_dependencies(manifest, &wit_dir, Some(lock_file), client).await?;
     lock_file.update_dependencies(&dependencies);
     populate_dependencies(wit_dir, &dependencies, output).await
 }
@@ -242,19 +242,19 @@ pub(crate) fn get_local_dependencies(
 }
 
 /// Builds a list of resolved dependencies loaded from the component or path containing the WIT.
-/// This will configure the resolver, override any dependencies from configuration and resolve the
+/// This will configure the resolver, override any dependencies from manifest and resolve the
 /// dependency map. This map can then be used in various other functions for fetching the
 /// dependencies and/or building a final resolved package.
 pub async fn resolve_dependencies(
-    config: &Manifest,
+    manifest: &Manifest,
     path: impl AsRef<Path>,
     lock_file: Option<&LockFile>,
     client: CachingClient<FileCache>,
 ) -> Result<DependencyResolutionMap> {
     let mut resolver = DependencyResolver::new_with_client(client, lock_file)?;
-    // add deps from config first in case they're local deps and then add deps from the directory
-    if let Some(overrides) = config.overrides.as_ref() {
-        tracing::debug!("detected config overrides");
+    // add deps from manifest first in case they're local deps and then add deps from the directory
+    if let Some(overrides) = manifest.overrides.as_ref() {
+        tracing::debug!("detected manifest overrides");
         for (pkg, ovr) in overrides.iter() {
             let pkg: PackageRef = pkg.parse().context("Unable to parse as a package ref")?;
             let dep = match (ovr.path.as_ref(), ovr.version.as_ref()) {

--- a/crates/wasm-pkg-core/src/wit.rs
+++ b/crates/wasm-pkg-core/src/wit.rs
@@ -19,7 +19,7 @@ use wit_component::WitPrinter;
 use wit_parser::{PackageId, PackageName, Resolve};
 
 use crate::{
-    config::Config,
+    config::Manifest,
     lock::LockFile,
     resolver::{
         DecodedDependency, Dependency, DependencyGraph, DependencyResolution,
@@ -54,7 +54,7 @@ impl FromStr for OutputType {
 /// Builds a WIT package given the configuration and directory to parse. Will update the given lock
 /// file with the resolved dependencies but will not write it to disk.
 pub async fn build_package(
-    config: &Config,
+    config: &Manifest,
     wit_dir: impl AsRef<Path>,
     lock_file: &mut LockFile,
     client: CachingClient<FileCache>,
@@ -130,7 +130,7 @@ pub async fn build_package(
 ///
 /// This is mostly a convenience wrapper around [`resolve_dependencies`] and [`populate_dependencies`].
 pub async fn fetch_dependencies(
-    config: &Config,
+    config: &Manifest,
     wit_dir: impl AsRef<Path>,
     lock_file: &mut LockFile,
     client: CachingClient<FileCache>,
@@ -246,7 +246,7 @@ pub(crate) fn get_local_dependencies(
 /// dependency map. This map can then be used in various other functions for fetching the
 /// dependencies and/or building a final resolved package.
 pub async fn resolve_dependencies(
-    config: &Config,
+    config: &Manifest,
     path: impl AsRef<Path>,
     lock_file: Option<&LockFile>,
     client: CachingClient<FileCache>,

--- a/crates/wasm-pkg-core/tests/build.rs
+++ b/crates/wasm-pkg-core/tests/build.rs
@@ -1,4 +1,4 @@
-use wasm_pkg_core::{config::Manifest, lock::LockFile};
+use wasm_pkg_core::{lock::LockFile, manifest::Manifest};
 use wit_component::DecodedWasm;
 use wit_parser::Stability;
 

--- a/crates/wasm-pkg-core/tests/build.rs
+++ b/crates/wasm-pkg-core/tests/build.rs
@@ -1,4 +1,4 @@
-use wasm_pkg_core::{config::Config as WkgConfig, lock::LockFile};
+use wasm_pkg_core::{config::Manifest, lock::LockFile};
 use wit_component::DecodedWasm;
 use wit_parser::Stability;
 
@@ -14,7 +14,7 @@ async fn test_build_wit() {
         .expect("Should be able to create a new lock file");
     let (_temp_cache, client) = common::get_client().await.unwrap();
     let (pkg, version, bytes) = wasm_pkg_core::wit::build_package(
-        &WkgConfig::default(),
+        &Manifest::default(),
         fixture_path.join("wit"),
         &mut lock,
         client,
@@ -107,7 +107,7 @@ async fn test_bad_dep_failure() {
         .expect("Should be able to write the world file");
 
     wasm_pkg_core::wit::build_package(
-        &WkgConfig::default(),
+        &Manifest::default(),
         fixture_path.join("wit"),
         &mut lock,
         client,

--- a/crates/wasm-pkg-core/tests/fetch.rs
+++ b/crates/wasm-pkg-core/tests/fetch.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, path::Path};
 use rstest::rstest;
 use tokio::process::Command;
 use wasm_pkg_core::{
-    config::{Manifest, Override},
     lock::LockFile,
+    manifest::{Manifest, Override},
     wit::{self, OutputType},
 };
 
@@ -55,8 +55,8 @@ async fn test_nested_local(#[values(OutputType::Wasm, OutputType::Wit)] output: 
     let mut lock = LockFile::new_with_path([], &lock_file)
         .await
         .expect("Should be able to create a new lock file");
-    let mut config = Manifest::default();
-    let overrides = config.overrides.get_or_insert(HashMap::default());
+    let mut manifest = Manifest::default();
+    let overrides = manifest.overrides.get_or_insert(HashMap::default());
     overrides.insert(
         "my:local".to_string(),
         Override {
@@ -66,9 +66,15 @@ async fn test_nested_local(#[values(OutputType::Wasm, OutputType::Wit)] output: 
     );
     let (_temp_cache, client) = common::get_client().await.unwrap();
 
-    wit::fetch_dependencies(&config, project_path.join("wit"), &mut lock, client, output)
-        .await
-        .expect("Should be able to fetch the dependencies");
+    wit::fetch_dependencies(
+        &manifest,
+        project_path.join("wit"),
+        &mut lock,
+        client,
+        output,
+    )
+    .await
+    .expect("Should be able to fetch the dependencies");
 
     assert_eq!(
         lock.packages.len(),
@@ -92,7 +98,7 @@ async fn test_transitive_local(#[values(OutputType::Wasm, OutputType::Wit)] outp
     // "example-c:baz" = { "path" = "../example-c/wit" }
     // "example-c:nested" = { "path" = "../example-c/wit/nested" }
     // ```
-    let config = Manifest {
+    let manifest = Manifest {
         overrides: Some(HashMap::from([
             (
                 "example-b:bar".to_string(),
@@ -121,9 +127,15 @@ async fn test_transitive_local(#[values(OutputType::Wasm, OutputType::Wit)] outp
     let (_temp_cache, client) = common::get_client().await.unwrap();
 
     // If overrides didn't properly resolve, this will fail
-    wit::fetch_dependencies(&config, project_path.join("wit"), &mut lock, client, output)
-        .await
-        .unwrap_or_else(|e| panic!("Should be able to fetch the dependencies: {e:#}"));
+    wit::fetch_dependencies(
+        &manifest,
+        project_path.join("wit"),
+        &mut lock,
+        client,
+        output,
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Should be able to fetch the dependencies: {e:#}"));
 
     // Ensure that the deps directory contains the correct dependencies
     let mut deps_dir = tokio::fs::read_dir(project_path.join("wit").join("deps"))

--- a/crates/wasm-pkg-core/tests/fetch.rs
+++ b/crates/wasm-pkg-core/tests/fetch.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path};
 use rstest::rstest;
 use tokio::process::Command;
 use wasm_pkg_core::{
-    config::{Config, Override},
+    config::{Manifest, Override},
     lock::LockFile,
     wit::{self, OutputType},
 };
@@ -27,7 +27,7 @@ async fn test_fetch(
     let (_temp_cache, client) = common::get_client().await.unwrap();
 
     wit::fetch_dependencies(
-        &Config::default(),
+        &Manifest::default(),
         fixture_path.join("wit"),
         &mut lock,
         client,
@@ -55,7 +55,7 @@ async fn test_nested_local(#[values(OutputType::Wasm, OutputType::Wit)] output: 
     let mut lock = LockFile::new_with_path([], &lock_file)
         .await
         .expect("Should be able to create a new lock file");
-    let mut config = Config::default();
+    let mut config = Manifest::default();
     let overrides = config.overrides.get_or_insert(HashMap::default());
     overrides.insert(
         "my:local".to_string(),
@@ -92,7 +92,7 @@ async fn test_transitive_local(#[values(OutputType::Wasm, OutputType::Wit)] outp
     // "example-c:baz" = { "path" = "../example-c/wit" }
     // "example-c:nested" = { "path" = "../example-c/wit/nested" }
     // ```
-    let config = Config {
+    let config = Manifest {
         overrides: Some(HashMap::from([
             (
                 "example-b:bar".to_string(),

--- a/crates/wkg/src/wit.rs
+++ b/crates/wkg/src/wit.rs
@@ -119,7 +119,7 @@ pub async fn build_wit_dir(
     lock_file: &mut LockFile,
 ) -> anyhow::Result<(PackageRef, Option<Version>, Vec<u8>)> {
     check_dir(&dir).await?;
-    let wkg_config = wasm_pkg_core::config::Manifest::load().await?;
+    let wkg_config = wasm_pkg_core::manifest::Manifest::load().await?;
     let result = wit::build_package(&wkg_config, dir.as_ref(), lock_file, client)
         .await
         .with_context(|| format!("failed to build WIT directory `{}`", dir.as_ref().display()))?;
@@ -150,7 +150,7 @@ impl FetchArgs {
     pub async fn run(self) -> anyhow::Result<()> {
         check_dir(&self.dir).await?;
         let client = self.common.get_client().await?;
-        let wkg_config = wasm_pkg_core::config::Manifest::load().await?;
+        let wkg_config = wasm_pkg_core::manifest::Manifest::load().await?;
         let mut lock_file = LockFile::load(false).await?;
         wit::fetch_dependencies(
             &wkg_config,
@@ -170,7 +170,7 @@ impl UpdateArgs {
     pub async fn run(self) -> anyhow::Result<()> {
         check_dir(&self.dir).await?;
         let client = self.common.get_client().await?;
-        let wkg_config = wasm_pkg_core::config::Manifest::load().await?;
+        let wkg_config = wasm_pkg_core::manifest::Manifest::load().await?;
         let mut lock_file = LockFile::load(false).await?;
         // Clear the lock file since we're updating it
         lock_file.packages.clear();

--- a/crates/wkg/src/wit.rs
+++ b/crates/wkg/src/wit.rs
@@ -119,7 +119,7 @@ pub async fn build_wit_dir(
     lock_file: &mut LockFile,
 ) -> anyhow::Result<(PackageRef, Option<Version>, Vec<u8>)> {
     check_dir(&dir).await?;
-    let wkg_config = wasm_pkg_core::config::Config::load().await?;
+    let wkg_config = wasm_pkg_core::config::Manifest::load().await?;
     let result = wit::build_package(&wkg_config, dir.as_ref(), lock_file, client)
         .await
         .with_context(|| format!("failed to build WIT directory `{}`", dir.as_ref().display()))?;
@@ -150,7 +150,7 @@ impl FetchArgs {
     pub async fn run(self) -> anyhow::Result<()> {
         check_dir(&self.dir).await?;
         let client = self.common.get_client().await?;
-        let wkg_config = wasm_pkg_core::config::Config::load().await?;
+        let wkg_config = wasm_pkg_core::config::Manifest::load().await?;
         let mut lock_file = LockFile::load(false).await?;
         wit::fetch_dependencies(
             &wkg_config,
@@ -170,7 +170,7 @@ impl UpdateArgs {
     pub async fn run(self) -> anyhow::Result<()> {
         check_dir(&self.dir).await?;
         let client = self.common.get_client().await?;
-        let wkg_config = wasm_pkg_core::config::Config::load().await?;
+        let wkg_config = wasm_pkg_core::config::Manifest::load().await?;
         let mut lock_file = LockFile::load(false).await?;
         // Clear the lock file since we're updating it
         lock_file.packages.clear();

--- a/crates/wkg/src/wit.rs
+++ b/crates/wkg/src/wit.rs
@@ -8,6 +8,7 @@ use wasm_pkg_client::caching::{CachingClient, FileCache};
 use wasm_pkg_common::package::{PackageRef, Version};
 use wasm_pkg_core::{
     lock::LockFile,
+    manifest::Manifest,
     wit::{self, OutputType},
 };
 
@@ -119,8 +120,8 @@ pub async fn build_wit_dir(
     lock_file: &mut LockFile,
 ) -> anyhow::Result<(PackageRef, Option<Version>, Vec<u8>)> {
     check_dir(&dir).await?;
-    let wkg_config = wasm_pkg_core::manifest::Manifest::load().await?;
-    let result = wit::build_package(&wkg_config, dir.as_ref(), lock_file, client)
+    let manifest = Manifest::load().await?;
+    let result = wit::build_package(&manifest, dir.as_ref(), lock_file, client)
         .await
         .with_context(|| format!("failed to build WIT directory `{}`", dir.as_ref().display()))?;
     Ok(result)
@@ -150,10 +151,10 @@ impl FetchArgs {
     pub async fn run(self) -> anyhow::Result<()> {
         check_dir(&self.dir).await?;
         let client = self.common.get_client().await?;
-        let wkg_config = wasm_pkg_core::manifest::Manifest::load().await?;
+        let manifest = Manifest::load().await?;
         let mut lock_file = LockFile::load(false).await?;
         wit::fetch_dependencies(
-            &wkg_config,
+            &manifest,
             self.dir,
             &mut lock_file,
             client,
@@ -170,12 +171,12 @@ impl UpdateArgs {
     pub async fn run(self) -> anyhow::Result<()> {
         check_dir(&self.dir).await?;
         let client = self.common.get_client().await?;
-        let wkg_config = wasm_pkg_core::manifest::Manifest::load().await?;
+        let manifest = Manifest::load().await?;
         let mut lock_file = LockFile::load(false).await?;
         // Clear the lock file since we're updating it
         lock_file.packages.clear();
         wit::fetch_dependencies(
-            &wkg_config,
+            &manifest,
             self.dir,
             &mut lock_file,
             client,

--- a/crates/wkg/tests/e2e.rs
+++ b/crates/wkg/tests/e2e.rs
@@ -55,7 +55,7 @@ async fn build_and_publish_with_metadata() {
         .expect("Manifest should have annotations");
 
     let wkg_toml =
-        wasm_pkg_core::config::Config::load_from_path(fixture.fixture_path.join("wkg.toml"))
+        wasm_pkg_core::config::Manifest::load_from_path(fixture.fixture_path.join("wkg.toml"))
             .await
             .expect("Should be able to load wkg.toml");
     let meta = wkg_toml.metadata.expect("Should have metadata");

--- a/crates/wkg/tests/e2e.rs
+++ b/crates/wkg/tests/e2e.rs
@@ -55,7 +55,7 @@ async fn build_and_publish_with_metadata() {
         .expect("Manifest should have annotations");
 
     let wkg_toml =
-        wasm_pkg_core::config::Manifest::load_from_path(fixture.fixture_path.join("wkg.toml"))
+        wasm_pkg_core::manifest::Manifest::load_from_path(fixture.fixture_path.join("wkg.toml"))
             .await
             .expect("Should be able to load wkg.toml");
     let meta = wkg_toml.metadata.expect("Should have metadata");

--- a/crates/wkg/tests/e2e.rs
+++ b/crates/wkg/tests/e2e.rs
@@ -8,6 +8,7 @@ mod common;
 #[tokio::test]
 async fn build_and_publish_with_metadata() {
     use oci_client::{client::ClientConfig, manifest::OciManifest, Reference};
+    use wasm_pkg_core::manifest::{Manifest, MANIFEST_FILE_NAME};
 
     let (config, registry, _container) = common::start_registry().await;
 
@@ -47,18 +48,17 @@ async fn build_and_publish_with_metadata() {
     let manifest = if let OciManifest::Image(m) = manifest {
         m
     } else {
-        panic!("Manifest should be an image manifest");
+        panic!("OciManifest should be an image manifest");
     };
 
     let annotations = manifest
         .annotations
-        .expect("Manifest should have annotations");
+        .expect("OciManifest should have annotations");
 
-    let wkg_toml =
-        wasm_pkg_core::manifest::Manifest::load_from_path(fixture.fixture_path.join("wkg.toml"))
-            .await
-            .expect("Should be able to load wkg.toml");
-    let meta = wkg_toml.metadata.expect("Should have metadata");
+    let manifest = Manifest::load_from_path(fixture.fixture_path.join(MANIFEST_FILE_NAME))
+        .await
+        .expect("Should be able to load wkg manifest");
+    let meta = manifest.metadata.expect("Should have metadata");
 
     assert_eq!(
         annotations


### PR DESCRIPTION
### Description

The `wkg.toml` data structure is currently named `Config`:
https://github.com/bytecodealliance/wasm-pkg-tools/blob/b3e7d011cece9897db4ca8e161bfa6144d6cc131/crates/wasm-pkg-core/src/config.rs#L20-L23

...this causes a bit of confusion when conflated with the `wasm_pkg_common::config::Config` that maps to `config.toml`:
https://github.com/bytecodealliance/wasm-pkg-tools/blob/b3e7d011cece9897db4ca8e161bfa6144d6cc131/crates/wasm-pkg-common/src/config.rs#L30-L32

Using cargo as an inspiration, refer to `wkg.toml` as a `Manifest` instead.

* rename `*config*` to `*manifest*` in parameters and variables that reference `wasm_pkg_core::manifest::Manifest`
* rename `wasm_pkg_core::config` module to `wasm_pkg_core::manifest`
* `wasm_pkg_core::config::CONFIG_FILE_NAME` renamed to `wasm_pkg_core::manifest::MANIFEST_FILE_NAME`