### PR TITLE
refactor(cli): move `wkg wit <cmd>` subcommands to `wkg <cmd>`

### DIFF
--- a/crates/wkg/src/main.rs
+++ b/crates/wkg/src/main.rs
@@ -28,7 +28,7 @@ mod oci;
 mod wit;
 
 use oci::OciCommands;
-use wit::WitCommands;
+use wit::{BuildArgs, FetchArgs, UpdateArgs, WitCommands};
 
 use crate::wit::temp_wit_file;
 
@@ -105,6 +105,9 @@ enum Commands {
     /// Commands for interacting with OCI registries
     #[clap(subcommand)]
     Oci(OciCommands),
+    Build(BuildArgs),
+    Fetch(FetchArgs),
+    Update(UpdateArgs),
     /// Commands for interacting with WIT files and dependencies
     #[clap(subcommand)]
     Wit(WitCommands),
@@ -615,6 +618,12 @@ async fn main() -> anyhow::Result<()> {
         Commands::Get(args) => args.run().await,
         Commands::Publish(args) => args.run().await,
         Commands::Oci(args) => args.run().await,
-        Commands::Wit(args) => args.run().await,
+        Commands::Build(args) => args.run().await,
+        Commands::Fetch(args) => args.run().await,
+        Commands::Update(args) => args.run().await,
+        Commands::Wit(args) => {
+            eprintln!("warning: `wkg wit <command>` is deprecated; use `wkg <command>` instead");
+            args.run().await
+        }
     }
 }

--- a/crates/wkg/src/wit.rs
+++ b/crates/wkg/src/wit.rs
@@ -16,19 +16,8 @@ use crate::Common;
 /// Commands for interacting with wit
 #[derive(Debug, Subcommand)]
 pub enum WitCommands {
-    /// Build a WIT package from a directory. By default, this will fetch all dependencies needed
-    /// and encode them in the WIT package. This will generate a lock file that can be used to fetch
-    /// the dependencies in the future.
     Build(BuildArgs),
-    /// Fetch dependencies for a component. This will read the package containing the world(s) you
-    /// have defined in the given wit directory (`wit` by default). It will then fetch the
-    /// dependencies and write them to the `deps` directory along with a lock file. If no lock file
-    /// exists, it will fetch all dependencies. If a lock file exists, it will fetch any
-    /// dependencies that are not in the lock file and update the lock file. To update the lock
-    /// file, use the `update` command.
     Fetch(FetchArgs),
-    /// Update the lock file with the latest dependencies. This will update all dependencies and
-    /// generate a new lock file.
     Update(UpdateArgs),
 }
 
@@ -42,6 +31,9 @@ impl WitCommands {
     }
 }
 
+/// Build a WIT package from a directory. By default, this will fetch all dependencies needed
+/// and encode them in the WIT package. This will generate a lock file that can be used to fetch
+/// the dependencies in the future.
 #[derive(Debug, Args)]
 pub struct BuildArgs {
     /// The directory containing the WIT files to build.
@@ -57,6 +49,12 @@ pub struct BuildArgs {
     pub common: Common,
 }
 
+/// Fetch dependencies for a component. This will read the package containing the world(s) you
+/// have defined in the given wit directory (`wit` by default). It will then fetch the
+/// dependencies and write them to the `deps` directory along with a lock file. If no lock file
+/// exists, it will fetch all dependencies. If a lock file exists, it will fetch any
+/// dependencies that are not in the lock file and update the lock file. To update the lock
+/// file, use the `update` command.
 #[derive(Debug, Args)]
 pub struct FetchArgs {
     /// The directory containing the WIT files to fetch dependencies for.
@@ -72,6 +70,8 @@ pub struct FetchArgs {
     pub common: Common,
 }
 
+/// Update the lock file with the latest dependencies. This will update all dependencies and
+/// generate a new lock file.
 #[derive(Debug, Args)]
 pub struct UpdateArgs {
     /// The directory containing the WIT files to update dependencies for.


### PR DESCRIPTION
* add depracation warning to existing `wkg wit` commands

Current spead of subcommands for `wkg` is unintuitive with two top level commands that only work on WIT:

* `wkg publish`
* `wkg get`

The `wkg wit` namespace scoping no longer makes sense as Warg is being phased out in favour of OCI.