### PR TITLE
fix(ci): add riscv64 sources list explicitly for cross-rs

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -13,7 +13,10 @@ image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
 [target.riscv64gc-unknown-linux-gnu]
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH",
+    # NOTE: on Noble, dpkg --add-architecture does not do enough to add riscv64
+    # sources properly, so we do it manually below
+    'echo -e "Types: deb\nURIs: http://ports.ubuntu.com/ubuntu-ports\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nArchitectures: riscv64" >> /etc/apt/sources.list.d/ubuntu.sources',
+    "apt update && apt --assume-yes install libssl-dev:$CROSS_DEB_ARCH",
 ]
 env.passthrough = [
     "OPENSSL_LIB_DIR=/usr/lib/riscv64-linux-gnu",


### PR DESCRIPTION
This commit adds a hack to fix riscv64 cross builds which were missing libssl-dev packages on Ubuntu. While the package *is* present, attempting to install via the normal route seems to fail, and the existing package is not properly resolved.

By more explicitly adding riscv64 noble as a source, the libssl-dev:riscv64 package is properly picked up and used during the build.

This fix is admittedly fragile, but we are depending on the `edge` tag for cross-rs, which is inherently unstable (and likely caused this issue in the first place). Unfortunately the last non-`edge` release [is from years ago](https://github.com/cross-rs/cross/pkgs/container/riscv64gc-unknown-linux-gnu).

Alternatively a solution I'm open to is pinning the edge release, but this may also change out from under us given that the intermediate/past shas do not seem to be retained upstream.