### PR TITLE
clarify single-world requirement in extract_resolve_and_world_id

### DIFF
--- a/crates/wasm-pkg-client/src/decoded_component.rs
+++ b/crates/wasm-pkg-client/src/decoded_component.rs
@@ -222,7 +222,7 @@ fn extract_resolve_and_world_id(
         DecodedWasm::WitPackage(resolve, pkg) => {
             let world_id = resolve
                 .select_world(&[*pkg], None)
-                .map_err(Error::InvalidPackage)?;
+                .map_err(|e| Error::InvalidPackage(e.context("we currently do not support multiple wolds, etc...")))?;
             Ok((resolve, world_id))
         }
     }

--- a/crates/wasm-pkg-client/src/decoded_component.rs
+++ b/crates/wasm-pkg-client/src/decoded_component.rs
@@ -212,10 +212,8 @@ fn extract_package_version(decoded: &DecodedWasm) -> Result<(PackageRef, Version
 /// for semver checking.
 ///
 /// Semver checks compare two versions of the same component, and a
-/// component is defined by exactly one world; thus a `WitPackage` must
-/// define exactly one world.
-///
-/// A multi-world `WitPackage` describes multiple components that must be handled individually.
+/// component is defined by exactly one world. Therefore it is considered
+/// an error if a `WitPackage` defines more than one world.
 fn extract_resolve_and_world_id(
     decoded: &DecodedWasm,
 ) -> Result<(&wit_parser::Resolve, wit_parser::WorldId), Error> {

--- a/crates/wasm-pkg-client/src/decoded_component.rs
+++ b/crates/wasm-pkg-client/src/decoded_component.rs
@@ -208,10 +208,14 @@ fn extract_package_version(decoded: &DecodedWasm) -> Result<(PackageRef, Version
     Ok((package, version))
 }
 
-/// Borrow the inner `wit_parser::Resolve` and resolve a concrete `WorldId`.
-/// For a decoded component the world is fixed; for a WIT package we ask
-/// `Resolve::select_world` to pick one — deferred until needed so a
-/// multi-world WIT package can publish its first version unambiguously.
+/// Borrow the inner `wit_parser::Resolve` and resolve a concrete `WorldId`
+/// for semver checking.
+///
+/// Semver checks compare two versions of the same component, and a
+/// component is defined by exactly one world; thus a `WitPackage` must
+/// define exactly one world.
+///
+/// A multi-world `WitPackage` describes multiple components that must be handled individually.
 fn extract_resolve_and_world_id(
     decoded: &DecodedWasm,
 ) -> Result<(&wit_parser::Resolve, wit_parser::WorldId), Error> {


### PR DESCRIPTION
The original wording was factually inaccurate as wit_parser will not arbitrarily select a world from a wit package. 

Furthermore semver checks are performed on a per component basis so the wit package being decoded must too define as a single world. 

https://component-model.bytecodealliance.org/design/wit.html#worlds

>  a world describes the contract of a component. A world describes a set of imports and exports…