### PR TITLE
chore: 0.16.0-rc.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-client"
-version = "0.16.0"
+version = "0.16.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-common"
-version = "0.16.0"
+version = "0.16.0-rc.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-core"
-version = "0.16.0"
+version = "0.16.0-rc.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4190,7 +4190,7 @@ dependencies = [
 
 [[package]]
 name = "wkg"
-version = "0.16.0"
+version = "0.16.0-rc.0"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.16.0"
+version = "0.16.0-rc.0"
 authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 
 [workspace.dependencies]
-wasm-pkg-client = { version = "0.16.0", path = "crates/wasm-pkg-client" }
-wasm-pkg-common = { version = "0.16.0", path = "crates/wasm-pkg-common" }
-wasm-pkg-core = { version = "0.16.0", path = "crates/wasm-pkg-core" }
+wasm-pkg-client = { version = "0.16.0-rc.0", path = "crates/wasm-pkg-client" }
+wasm-pkg-common = { version = "0.16.0-rc.0", path = "crates/wasm-pkg-common" }
+wasm-pkg-core = { version = "0.16.0-rc.0", path = "crates/wasm-pkg-core" }
 
 anstream = "0.6"
 anstyle = "1.0"


### PR DESCRIPTION
Bump wkg crates to 0.16.0-rc.0