### PR TITLE
feat(config,client): provide a per-registry envvar scheme to set autentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-client"
-version = "0.16.0-rc.0"
+version = "0.16.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-common"
-version = "0.16.0-rc.0"
+version = "0.16.0-rc.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-core"
-version = "0.16.0-rc.0"
+version = "0.16.0-rc.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4190,7 +4190,7 @@ dependencies = [
 
 [[package]]
 name = "wkg"
-version = "0.16.0-rc.0"
+version = "0.16.0-rc.1"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.16.0-rc.0"
+version = "0.16.0-rc.1"
 authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 
 [workspace.dependencies]
-wasm-pkg-client = { version = "0.16.0-rc.0", path = "crates/wasm-pkg-client" }
-wasm-pkg-common = { version = "0.16.0-rc.0", path = "crates/wasm-pkg-common" }
-wasm-pkg-core = { version = "0.16.0-rc.0", path = "crates/wasm-pkg-core" }
+wasm-pkg-client = { version = "0.16.0-rc.1", path = "crates/wasm-pkg-client" }
+wasm-pkg-common = { version = "0.16.0-rc.1", path = "crates/wasm-pkg-common" }
+wasm-pkg-core = { version = "0.16.0-rc.1", path = "crates/wasm-pkg-core" }
 
 anstream = "0.6"
 anstyle = "1.0"

--- a/crates/wasm-pkg-client/src/oci/mod.rs
+++ b/crates/wasm-pkg-client/src/oci/mod.rs
@@ -114,6 +114,13 @@ impl OciBackend {
     }
 
     pub(crate) fn get_credentials(&self) -> Result<RegistryAuth, Error> {
+        // Prefer a bearer token from envvar if it exists
+        if let Ok(token) = std::env::var(registry_token_env_var(&self.oci_registry))
+            && !token.is_empty()
+        {
+            return Ok(RegistryAuth::Bearer(token));
+        }
+
         if let Some(BasicCredentials { username, password }) = &self.credentials {
             return Ok(RegistryAuth::Basic(
                 username.clone(),
@@ -176,6 +183,22 @@ pub(crate) fn oci_registry_error(err: OciDistributionError) -> Error {
     }
 }
 
+/// Returns the envvar used to provide a bearer token for a given registry:
+/// `WKG_REGISTRIES_<name>_TOKEN`, where registry `<name>` is defined by
+/// the resolution of [`wasm_pkg_common::config::Config`].
+///
+/// Any non-ASCII-alphanumeric characters (., -, :, /, ...) are replaced by `_` and
+/// the whole string is upper-cased.
+// TODO(mkatychev): move this into `wasm_pkg_common::config::Config` once overlays are implemented,
+// this should be a generic-to-backend way of overriding configs.
+fn registry_token_env_var(oci_registry: &str) -> String {
+    let sanitized: String = oci_registry
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    format!("WKG_REGISTRIES_{}_TOKEN", sanitized.to_ascii_uppercase())
+}
+
 fn get_docker_credential(registry: &str) -> Result<Option<RegistryAuth>, Error> {
     match docker_credential::get_credential(registry) {
         Ok(DockerCredential::UsernamePassword(username, password)) => {
@@ -202,4 +225,25 @@ fn get_docker_credential(registry: &str) -> Result<Option<RegistryAuth>, Error> 
     }
 
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_env_var_sanitizes_registry_name() {
+        assert_eq!(
+            registry_token_env_var("example.com"),
+            "WKG_REGISTRIES_EXAMPLE_COM_TOKEN"
+        );
+        assert_eq!(
+            registry_token_env_var("ghcr.io"),
+            "WKG_REGISTRIES_GHCR_IO_TOKEN"
+        );
+        assert_eq!(
+            registry_token_env_var("localhost:1234"),
+            "WKG_REGISTRIES_LOCALHOST_1234_TOKEN",
+        );
+    }
 }

--- a/crates/wasm-pkg-client/src/oci/mod.rs
+++ b/crates/wasm-pkg-client/src/oci/mod.rs
@@ -114,10 +114,13 @@ impl OciBackend {
     }
 
     pub(crate) fn get_credentials(&self) -> Result<RegistryAuth, Error> {
-        // Prefer a bearer token from envvar if it exists
-        if let Ok(token) = std::env::var(registry_token_env_var(&self.oci_registry))
+        // Detect `WKG_REGISTRY_<REGISTRY>_AUTH_<AUTH_SCHEME>` if present.
+        let auth_var_key = &registry_auth_env_var(&self.oci_registry, "BEARER");
+        if let Ok(token) = std::env::var(auth_var_key)
             && !token.is_empty()
         {
+            tracing::debug!(registry = %self.oci_registry, %auth_var_key, "Using detected authentication envvar key");
+            // Only `BEARER` AUTH_SCHEME for now
             return Ok(RegistryAuth::Bearer(token));
         }
 
@@ -183,20 +186,25 @@ pub(crate) fn oci_registry_error(err: OciDistributionError) -> Error {
     }
 }
 
-/// Returns the envvar used to provide a bearer token for a given registry:
-/// `WKG_REGISTRIES_<name>_TOKEN`, where registry `<name>` is defined by
-/// the resolution of [`wasm_pkg_common::config::Config`].
+/// Returns the envvar used to provide credentials for a given registry and
+/// auth scheme: `WKG_REGISTRY_<REGISTRY>_AUTH_<AUTH_SCHEME>`
+/// * `<REGISTRY>` : defined by the resolution of [`wasm_pkg_common::config::Config`] and
+/// * `<AUTH_SCHEME>`: the auth mechanism (`BEARER` only support)
 ///
-/// Any non-ASCII-alphanumeric characters (., -, :, /, ...) are replaced by `_` and
-/// the whole string is upper-cased.
+/// Any non-ASCII-alphanumeric characters (., -, :, /, ...) in the registry
+/// name are replaced by `_` and the whole string is upper-cased.
 // TODO(mkatychev): move this into `wasm_pkg_common::config::Config` once overlays are implemented,
 // this should be a generic-to-backend way of overriding configs.
-fn registry_token_env_var(oci_registry: &str) -> String {
+fn registry_auth_env_var(oci_registry: &str, scheme: &str) -> String {
     let sanitized: String = oci_registry
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
         .collect();
-    format!("WKG_REGISTRIES_{}_TOKEN", sanitized.to_ascii_uppercase())
+    format!(
+        "WKG_REGISTRY_{}_AUTH_{}",
+        sanitized.to_ascii_uppercase(),
+        scheme.to_ascii_uppercase(),
+    )
 }
 
 fn get_docker_credential(registry: &str) -> Result<Option<RegistryAuth>, Error> {
@@ -232,18 +240,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn token_env_var_sanitizes_registry_name() {
+    fn auth_env_var_sanitizes_registry_name() {
         assert_eq!(
-            registry_token_env_var("example.com"),
-            "WKG_REGISTRIES_EXAMPLE_COM_TOKEN"
+            registry_auth_env_var("example.com", "BEARER"),
+            "WKG_REGISTRY_EXAMPLE_COM_AUTH_BEARER"
         );
         assert_eq!(
-            registry_token_env_var("ghcr.io"),
-            "WKG_REGISTRIES_GHCR_IO_TOKEN"
+            registry_auth_env_var("ghcr.io", "BEARER"),
+            "WKG_REGISTRY_GHCR_IO_AUTH_BEARER"
         );
         assert_eq!(
-            registry_token_env_var("localhost:1234"),
-            "WKG_REGISTRIES_LOCALHOST_1234_TOKEN",
+            registry_auth_env_var("localhost:1234", "BEARER"),
+            "WKG_REGISTRY_LOCALHOST_1234_AUTH_BEARER",
+        );
+    }
+
+    #[test]
+    fn auth_env_var_upcases_scheme() {
+        assert_eq!(
+            registry_auth_env_var("example.com", "bearer"),
+            "WKG_REGISTRY_EXAMPLE_COM_AUTH_BEARER"
         );
     }
 }


### PR DESCRIPTION
This fills a gap where the only current ways of overriding configs through envvars are only through the `wkg oci` subcommands with `WKG_OCI_USERNAME` and `WKG_OCI_PASSWORD`:
https://github.com/bytecodealliance/wasm-pkg-tools/blob/6ca71800a5f7733c2276d16ce7ba679769468f9f/crates/wkg/src/oci.rs#L14-L32 

Many OCI registries do not expect a username/password scheme and instead want to be given a bearer token.

This attempts to fill the gap by exposing `WKG_REGISTRY_<REGISTRY>_AUTH_<AUTH_SCHEME>` as a means of providing credentials for a given registry.

This attempts to account for scenarios where multiple registries are authenticated with at once.